### PR TITLE
Odstranění SYSNO

### DIFF
--- a/migrace/999_prevod_null_hodnot_texty.sql
+++ b/migrace/999_prevod_null_hodnot_texty.sql
@@ -23,7 +23,6 @@ UPDATE dokument_extra_data SET region = '' WHERE region is NULL;
 UPDATE dokument_extra_data SET udalost = '' WHERE udalost is NULL;
 UPDATE dokumentacni_jednotka SET nazev = '' WHERE nazev is NULL;
 UPDATE externi_odkaz SET paginace = '' WHERE paginace is NULL;
-UPDATE externi_zdroj SET sysno = '' WHERE sysno is NULL;
 UPDATE externi_zdroj SET nazev = '' WHERE nazev is NULL;
 UPDATE externi_zdroj SET edice_rada = '' WHERE edice_rada is NULL;
 UPDATE externi_zdroj SET sbornik_nazev = '' WHERE sbornik_nazev is NULL;

--- a/migrace/migrace_mazani.sql
+++ b/migrace/migrace_mazani.sql
@@ -493,3 +493,6 @@ CREATE TABLE pom AS
 DELETE FROM historie USING pom WHERE historie.id = pom.id;
 DELETE FROM historie_vazby USING pom WHERE historie_vazby.id = pom.id;
 DROP TABLE pom;
+
+-- Odstranění sysno
+ALTER TABLE externi_zdroj DROP COLUMN sysno;

--- a/webclient/ez/filters.py
+++ b/webclient/ez/filters.py
@@ -51,12 +51,6 @@ class ExterniZdrojFilter(HistorieFilter, FilterSet):
         distinct=True,
     )
 
-    sysno = CharFilter(
-        label=_("ez.filters.sysno.label"),
-        lookup_expr="icontains",
-        distinct=True,
-    )
-
     typ = ModelMultipleChoiceFilter(
         queryset=Heslar.objects.filter(nazev_heslare=HESLAR_EXTERNI_ZDROJ_TYP),
         label=_("ez.filters.typ.label"),
@@ -225,7 +219,6 @@ class ExterniZdrojFilterFormHelper(crispy_forms.helper.FormHelper):
             Div(
                 Div(
                     Div("ident_cely", css_class="col-sm-2"),
-                    Div("sysno", css_class="col-sm-2"),
                     Div("typ", css_class="col-sm-2"),
                     Div("stav", css_class="col-sm-2"),
                     Div("autori", css_class="col-sm-2"),

--- a/webclient/ez/forms.py
+++ b/webclient/ez/forms.py
@@ -58,7 +58,6 @@ class ExterniZdrojForm(forms.ModelForm):
             "organizace",
             "link",
             "poznamka",
-            "sysno",
         )
 
         labels = {
@@ -79,7 +78,6 @@ class ExterniZdrojForm(forms.ModelForm):
             "organizace": _("ez.forms.externiZdrojForm.organizace.label"),
             "link": _("ez.forms.externiZdrojForm.link.label"),
             "poznamka": _("ez.forms.externiZdrojForm.poznamka.label"),
-            "sysno": _("ez.forms.externiZdrojForm.sysno.label"),
         }
 
         widgets = {
@@ -106,7 +104,6 @@ class ExterniZdrojForm(forms.ModelForm):
             "organizace": forms.TextInput(),
             "link": forms.TextInput(),
             "poznamka": forms.TextInput(),
-            "sysno": forms.TextInput(),
         }
 
         help_texts = {
@@ -127,7 +124,6 @@ class ExterniZdrojForm(forms.ModelForm):
             "organizace": _("ez.forms.externiZdrojForm.organizace.tooltip"),
             "link": _("ez.forms.externiZdrojForm.link.tooltip"),
             "poznamka": _("ez.forms.externiZdrojForm.poznamka.tooltip"),
-            "sysno": _("ez.forms.externiZdrojForm.sysno.tooltip"),
         }
 
     def __init__(
@@ -181,7 +177,6 @@ class ExterniZdrojForm(forms.ModelForm):
                 Div("organizace", css_class="col-sm-2"),
                 Div("link", css_class="col-sm-8"),
                 Div("poznamka", css_class="col-sm-10"),
-                Div("sysno", css_class="col-sm-2"),
                 css_class="row",
             ),
         )

--- a/webclient/ez/migrations/0001_initial.py
+++ b/webclient/ez/migrations/0001_initial.py
@@ -16,7 +16,6 @@ class Migration(migrations.Migration):
             name='ExterniZdroj',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('sysno', models.TextField(blank=True, null=True)),
                 ('nazev', models.TextField(blank=True, null=True)),
                 ('edice_rada', models.TextField(blank=True, null=True)),
                 ('sbornik_nazev', models.TextField(blank=True, null=True)),

--- a/webclient/ez/models.py
+++ b/webclient/ez/models.py
@@ -37,7 +37,6 @@ class ExterniZdroj(ExportModelOperationsMixin("externi_zdroj"), ModelWithMetadat
         (EZ_STAV_POTVRZENY, _("ez.models.externiZdroj.states.potvrzeny.label")),
     )
 
-    sysno = models.TextField(blank=True, null=True)
     typ = models.ForeignKey(
         Heslar,
         models.RESTRICT,

--- a/webclient/ez/tables.py
+++ b/webclient/ez/tables.py
@@ -21,7 +21,6 @@ class ExterniZdrojTable(SearchTable):
     casopis_denik_nazev = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.casopis_denik_nazev.label"))
     casopis_rocnik = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.casopis_rocnik.label"))
     sbornik_nazev = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.sbornik_nazev.label"))
-    sysno = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.sysno.label"))
     stav = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.stav.label"))
     typ = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.typ.label"))
     rok_vydani_vzniku = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.rok_vydani_vzniku.label"))
@@ -38,7 +37,6 @@ class ExterniZdrojTable(SearchTable):
     misto = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.misto.label"))
     nazev = tables.columns.Column(default="", verbose_name=_("ez.tables.ezTable.nazev.label"))
     columns_to_hide = (
-        "sysno",
         "datum_rd",
         "edice_rada",
         "misto",
@@ -64,7 +62,6 @@ class ExterniZdrojTable(SearchTable):
             "casopis_denik_nazev",
             "casopis_rocnik",
             "sbornik_nazev",
-            "sysno",
             "datum_rd",
             "edice_rada",
             "misto",
@@ -79,7 +76,6 @@ class ExterniZdrojTable(SearchTable):
         )
         sequence = (
             "ident_cely",
-            "sysno",
             "stav",
             "typ",
             "autori",

--- a/webclient/xml_generator/definitions/amcr.xsd
+++ b/webclient/xml_generator/definitions/amcr.xsd
@@ -144,7 +144,6 @@
       <xs:element name="ident_cely" minOccurs="1" maxOccurs="1" type="xs:string"/> <!-- "{ident_cely}" -->
       <xs:element name="stav" minOccurs="1" maxOccurs="1" type="xs:integer"/> <!-- "{stav}" -->
       <xs:element name="typ" minOccurs="1" maxOccurs="1" type="amcr:vocabType"/> <!-- "{typ.ident_cely}" | "{typ.heslo}" -->
-      <xs:element name="sysno" minOccurs="0" maxOccurs="1" type="xs:string"/> <!-- "{sysno}" -->
       <xs:element name="autor" minOccurs="0" maxOccurs="unbounded" type="amcr:autorType"/> <!-- "{externizdrojautor_set.autor.ident_cely}" | "{externizdrojautor_set.poradi}" | "{externizdrojautor_set.autor.vypis_cely}" -->
       <xs:element name="nazev" minOccurs="0" maxOccurs="1" type="xs:string"/> <!-- "{nazev}" -->
       <xs:element name="edice_rada" minOccurs="0" maxOccurs="1" type="xs:string"/> <!-- "{edice_rada}" -->

--- a/webclient/xml_generator/definitions/metadata.xml
+++ b/webclient/xml_generator/definitions/metadata.xml
@@ -323,7 +323,6 @@
     <amcr:ident_cely>BIB-123456</amcr:ident_cely>
     <amcr:stav>1</amcr:stav>
     <amcr:typ id="HES-123456" xml:lang="cs">kniha</amcr:typ>
-    <amcr:sysno>9874-1</amcr:sysno>
     <amcr:autor id="OS-123456" poradi="1">Novák, Jan</amcr:autor>
     <amcr:nazev>Knížka</amcr:nazev>
     <amcr:edice_rada>To nejlepší z archeologie</amcr:edice_rada>

--- a/webclient/xml_generator/definitions/oai_amcr.xsd
+++ b/webclient/xml_generator/definitions/oai_amcr.xsd
@@ -144,7 +144,6 @@
       <xs:element name="ident_cely" minOccurs="1" maxOccurs="1" type="xs:string"/> 
       <xs:element name="stav" minOccurs="1" maxOccurs="1" type="xs:integer"/> 
       <xs:element name="typ" minOccurs="1" maxOccurs="1" type="amcr:vocabType"/> 
-      <xs:element name="sysno" minOccurs="0" maxOccurs="1" type="xs:string"/> 
       <xs:element name="autor" minOccurs="0" maxOccurs="unbounded" type="amcr:autorType"/> 
       <xs:element name="nazev" minOccurs="0" maxOccurs="1" type="xs:string"/> 
       <xs:element name="edice_rada" minOccurs="0" maxOccurs="1" type="xs:string"/> 


### PR DESCRIPTION
Odebrání dalšího nadbytečného sloupce. Asi bude třeba nad DB po nasazení spustit: `ALTER TABLE externi_zdroj DROP COLUMN sysno;`

Jinak jsem to dal do SQL migrací, takže Django migrace by neměla být třeba.