### PR TITLE
Dočasně spuštěn uwsgi server jako root, než odhalíme pravou příčinu.

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -12,7 +12,7 @@ python3 manage.py compress --force
 python3 manage.py migrate
 python3 manage.py shell < data_management.py
 python3 manage.py set_database_rights
-python3 manage.py update_snapshot_fields
+#python3 manage.py update_snapshot_fields
 
 CONFIG_FILE="/run/secrets/db_conf"
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -89,4 +89,5 @@ for lang_item in ${languages[@]}; do
 
 done
 
-uwsgi /scripts/uwsgi_site.ini
+#docasne se sudo
+sudo uwsgi /scripts/uwsgi_site.ini


### PR DESCRIPTION
Dočasně spuštěn uwsgi server jako root, než odhalíme pravou příčinu problému #1969. Uwsgi  server má problém s kill všech svých běžících processů, Pravděpodobně je někde chyba v oprávněních. Bude nutný ještě průzkum.
Vypnutá update_snapshot_fields, u nově migrované databáze může trvat dlouho #1713. 
Spustí se v Django shellu příkazem
import cron.tasks; cron.tasks.update_snapshot_fields()