### PR TITLE
#2209 Oprava předávání IP adresy proxy serveru

### DIFF
--- a/docker-compose-production-proxy.yml
+++ b/docker-compose-production-proxy.yml
@@ -7,7 +7,10 @@ services:
       - static_data:/vol/static
       - nginx_data:/vol/nginx/data
     ports:
-      - "8080:8080"
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: host
     networks:
       - prod-net
     healthcheck:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -34,12 +34,15 @@ services:
 
 
   proxy:
-    image: aiscr/webamcr-proxy:latest
+    image: docker.io/library/test_proxy
     volumes:
       - static_data:/vol/static
       - nginx_data:/vol/nginx/data
     ports:
-      - "8080:8080"
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: host
     networks:
       - prod-net
     healthcheck:

--- a/scripts/build_prod_image.sh
+++ b/scripts/build_prod_image.sh
@@ -3,3 +3,4 @@
 
 #Wrapper for building production image locally
 docker build -t test_prod -f Dockerfile-production --build-arg VERSION_APP="$(git rev-parse --short HEAD | head -c 8)" --build-arg TAG_APP=local_build  .
+docker build -t test_proxy -f proxy/Dockerfile --build-arg VERSION_APP="$(git rev-parse --short HEAD | head -c 8)" --build-arg TAG_APP=local_build  ./proxy


### PR DESCRIPTION
#2209 Toto nastavení (mode : host) znemožňuje spuštění více instancí proxy serveru, což nám ale myslím vůbec nevadí.
Upravil jsem také build_prod_image.sh, aby generoval také image proxy serveru, může se hodit pro ladění.