### PR TITLE
2680 Odstranění max délky názvu katastru v PAS

### DIFF
--- a/webclient/pas/forms.py
+++ b/webclient/pas/forms.py
@@ -147,7 +147,6 @@ class CreateSamostatnyNalezForm(forms.ModelForm):
     """
 
     katastr = forms.CharField(
-        max_length=50,
         label=_("pas.forms.createSamostatnyNalezForm.katastr.label"),
         error_messages={"required": _("pas.forms.createSamostatnyNalezForm.katastr.errorMessage")},
         help_text=_("pas.forms.createSamostatnyNalezForm.katastr.tooltip"),


### PR DESCRIPTION
#2650
Nedává smysl mít omezení na maximální délku políčka, které se vyplňuje automaticky.