### PR TITLE
Oprava miniatur a odstranění souřadnic z exif

### DIFF
--- a/webclient/core/models.py
+++ b/webclient/core/models.py
@@ -8,6 +8,7 @@ import zipfile
 from typing import Optional, Union
 
 import magic
+import piexif
 import py7zr
 import rarfile
 from core.constants import ROLE_ARCHEOLOG_ID, ROLE_ARCHIVAR_ID, ROLE_BADATEL_ID
@@ -29,6 +30,7 @@ from historie.models import Historie, HistorieVazby
 from nalez.models import NalezObjekt, NalezPredmet
 from notifikace_projekty.models import Pes
 from pian.models import Pian
+from PIL import Image
 from uzivatel.models import User
 from xml_generator.models import ModelWithMetadata
 
@@ -372,6 +374,42 @@ class Soubor(ExportModelOperationsMixin("soubor"), models.Model):
                 "core.models.Soubor.get_mime_type.end", extra={"mime_type": mime_type, "check_archive": check_archive}
             )
             return mime_type
+
+    @classmethod
+    def remove_gps_data(cls, bytes_io: io.BytesIO) -> io.BytesIO:
+        try:
+            img = Image.open(bytes_io)
+        except Exception as err:
+            logger.warning("core.models.Soubor.remove_gps_data.cannot_open_file", extra={"err": err})
+            bytes_io.seek(0)
+            return bytes_io
+        exif_data = img.getexif()
+        if not exif_data:
+            bytes_io.seek(0)
+            return bytes_io
+
+        exif_dict = piexif.load(img.info.get("exif"))
+
+        # Odstranění GPS dat, pokud existují
+        if "GPS" in exif_dict and exif_dict["GPS"] != {}:
+            del exif_dict["GPS"]
+        else:
+            logger.debug("core.models.Soubor.remove_gps_data.no_GPS_data")
+            bytes_io.seek(0)
+            return bytes_io
+        if 41729 in exif_dict["Exif"] and isinstance(exif_dict["Exif"][41729], int):
+            exif_dict["Exif"][41729] = str(exif_dict["Exif"][41729]).encode("utf-8")
+        try:
+            new_exif_bytes = piexif.dump(exif_dict)
+            output_io = io.BytesIO()
+            img.save(output_io, format=img.format, exif=new_exif_bytes)
+            output_io.seek(0)
+            logger.debug("core.models.Soubor.remove_gps_data.GPS_data_removed")
+            return output_io
+        except Exception as err:
+            logger.error("core.models.Soubor.remove_gps_data.cannot_save_file", extra={"err": err})
+            bytes_io.seek(0)
+            return bytes_io
 
     @classmethod
     def check_mime_for_url(cls, file, source_url=""):

--- a/webclient/core/repository_connector.py
+++ b/webclient/core/repository_connector.py
@@ -1183,7 +1183,7 @@ class FedoraRepositoryConnector:
             rep_bin_file = conn.get_binary_file(record.repository_uuid)
             if rep_bin_file:
                 conn.save_thumbs(record.nazev, rep_bin_file.content, record.repository_uuid)
-                fedora_transaction.mark_transaction_as_closed()
+        fedora_transaction.mark_transaction_as_closed()
 
     @classmethod
     def generate_thumbs(cls, records: Union[list, range]) -> None:
@@ -1287,6 +1287,41 @@ class FedoraRepositoryConnector:
             try:
                 soubor = Soubor.objects.get(path=row["record"])
                 FedoraRepositoryConnector.generate_thumb_for_single_file(soubor.pk)
+            except Exception as err:
+                print(f"Chyba: {row['record']} {err}")
+
+    @classmethod
+    def remove_GPS_data_from_existing_files(cls, uploaded_file: str) -> None:
+        import pandas as pd
+        from core.models import Soubor
+        from xml_generator.models import ModelWithMetadata
+
+        sheet = pd.read_csv(uploaded_file, sep=",")
+        c = len(sheet)
+        for index, row in sheet.iterrows():
+            if index % max(c // 100, 1) == 0:
+                print(f"\r{round(index / c * 100)}%", end="")
+            try:
+                record = Soubor.objects.get(path=row["record"])
+
+                related_record: ModelWithMetadata = record.vazba.navazany_objekt
+                fedora_transaction = FedoraTransaction()
+                record.active_transaction = fedora_transaction
+                conn = FedoraRepositoryConnector(related_record, fedora_transaction)
+
+                rep_bin_file = conn.get_binary_file(record.repository_uuid)
+                if rep_bin_file:
+                    rep_bin_file_new = Soubor.remove_gps_data(rep_bin_file.content)
+                    if rep_bin_file_new is not rep_bin_file.content:
+                        rep_bin_file = conn.update_binary_file(
+                            record.nazev, record.mimetype, rep_bin_file_new, record.repository_uuid
+                        )
+                        record.size_mb = rep_bin_file.size_mb
+                        record.sha_512 = rep_bin_file.sha_512
+                        record.save()
+
+                fedora_transaction.mark_transaction_as_closed()
+
             except Exception as err:
                 print(f"Chyba: {row['record']} {err}")
 

--- a/webclient/core/repository_connector.py
+++ b/webclient/core/repository_connector.py
@@ -13,7 +13,7 @@ from core.connectors import RedisConnector
 from core.utils import get_mime_type, replace_last
 from django.conf import settings
 from pdf2image import convert_from_bytes
-from PIL import Image
+from PIL import Image, ImageOps
 from requests.auth import HTTPBasicAuth
 from xml_generator.generator import DocumentGenerator
 from xml_generator.models import ModelWithMetadata
@@ -707,6 +707,7 @@ class FedoraRepositoryConnector:
 
         def resize_image(image: BytesIO, large_inner=False):
             image = Image.open(image)
+            image = ImageOps.exif_transpose(image)
             max_size = ((1 + large_inner * 7) * 100, (1 + large_inner * 7) * 100)
             image.thumbnail(max_size)
             output_buffer = BytesIO()
@@ -719,7 +720,6 @@ class FedoraRepositoryConnector:
 
             thumb_icon, mime_type = Soubor.get_thumb_icon(file_content)
             if mime_type.startswith("image/"):
-                file_content = thumb_icon
                 try:
                     thumbnail = resize_image(file_content, large)
                     logger.debug(
@@ -740,6 +740,8 @@ class FedoraRepositoryConnector:
                                 extra={"err": err, "file_name": file_name, "large": large},
                             )
                     return None
+            else:
+                return resize_image(thumb_icon, large)
 
         if file_name.lower().endswith(".pdf"):
             try:
@@ -1271,6 +1273,22 @@ class FedoraRepositoryConnector:
         queryset = Soubor.objects.filter(pk__in=records).order_by("pk")
         for item in queryset:
             cls.save_single_file_from_storage(item, storage_path, save_thumbs, disable_antivirus)
+
+    @classmethod
+    def create_missing_thumbnail(cls, uploaded_file: str) -> None:
+        import pandas as pd
+        from core.models import Soubor
+
+        sheet = pd.read_csv(uploaded_file, sep=",")
+        c = len(sheet)
+        for index, row in sheet.iterrows():
+            if index % max(c // 100, 1) == 0:
+                print(f"\r{round(index / c * 100)}%", end="")
+            try:
+                soubor = Soubor.objects.get(path=row["record"])
+                FedoraRepositoryConnector.generate_thumb_for_single_file(soubor.pk)
+            except Exception as err:
+                print(f"Chyba: {row['record']} {err}")
 
 
 class FedoraTransactionQueueClosedError(Exception):

--- a/webclient/core/views.py
+++ b/webclient/core/views.py
@@ -18,6 +18,7 @@ from core.constants import (
     ROLE_ARCHEOLOG_ID,
     ROLE_ARCHIVAR_ID,
     ROLE_BADATEL_ID,
+    SAMOSTATNY_NALEZ_RELATION_TYPE,
 )
 from core.forms import CheckStavNotChangedForm, TransaltionImportForm
 from core.ident_cely import get_record_from_ident
@@ -440,6 +441,8 @@ def post_upload(request):
                 )
             else:
                 renamed = False
+            if mimetype in ["image/png", "image/jpeg", "image/tiff"] and samostatny_nalez.exists():
+                soubor_data = Soubor.remove_gps_data(soubor_data)
             try:
                 rep_bin_file = conn.save_binary_file(new_name, mimetype, soubor_data)
             except FedoraUpdatedByAnotherTransactionError as err:
@@ -539,6 +542,11 @@ def post_upload(request):
                 )
             else:
                 renamed = False
+            if (
+                mimetype in ["image/png", "image/jpeg", "image/tiff"]
+                and soubor_instance.vazba.typ_vazby == SAMOSTATNY_NALEZ_RELATION_TYPE
+            ):
+                soubor_data = Soubor.remove_gps_data(soubor_data)
             if soubor_instance.repository_uuid is not None:
                 extension = soubor.name.split(".")[-1]
                 new_name = f'{".".join(soubor_instance.nazev.split(".")[:-1])}.{extension}'

--- a/webclient/requirements.txt
+++ b/webclient/requirements.txt
@@ -19,6 +19,7 @@ reportlab==4.2.5
 PyRTF3==0.47.5
 pypdf==5.2.0
 Pillow==11.1.0
+piexif==1.1.3
 beautifulsoup4==4.12.3
 django-extensions==3.2.3
 celery==5.4.0


### PR DESCRIPTION
#2608
#2727 
Pro přidání chybějících miniatur je potřeba v django shell spustit příkaz 
from core.repository_connector import FedoraRepositoryConnector
FedoraRepositoryConnector.create_missing_thumbnail("/vol/data-migrace/seznam.csv")

kde seznam.csv má formát získaný uložením výsledku sql dotazu https://github.com/ARUP-CAS/aiscr-webamcr/issues/2608#issuecomment-2627434157
"record"
"rest/AMCR/record/C-202500001/file/8db90833-403d-47ae-82f8-047874e5a75a"
"rest/AMCR/record/M-202500013/file/88441aa7-182d-4052-9eca-f61d49b9dae6"
"rest/AMCR/record/C-202500007/file/0a90b7f7-b53a-4877-be39-1342d1b02cc7"
"rest/AMCR/record/C-202500010/file/363539b0-2edc-48e8-aa00-8c22e64458df"

