### PR TITLE
Oprava kruhového importu

### DIFF
--- a/webclient/core/log_middleware.py
+++ b/webclient/core/log_middleware.py
@@ -1,0 +1,22 @@
+import threading
+
+log_request_data = threading.local()
+
+
+class LogMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        log_request_data.url = request.path
+        log_request_data.user_id = request.user.ident_cely if request.user.is_authenticated else None
+        response = self.get_response(request)
+        return response
+
+    @staticmethod
+    def get_request_url():
+        return getattr(log_request_data, "url", None)
+
+    @staticmethod
+    def get_user_id():
+        return getattr(log_request_data, "user_id", None)

--- a/webclient/core/logging_filters.py
+++ b/webclient/core/logging_filters.py
@@ -3,7 +3,7 @@ import logging
 
 class UserLogFilter(logging.Filter):
     def filter(self, record):
-        from core.middleware import LogMiddleware
+        from core.log_middleware import LogMiddleware
 
         record.url = LogMiddleware.get_request_url()
         record.user_id = LogMiddleware.get_user_id() or "Anonymous"

--- a/webclient/core/middleware.py
+++ b/webclient/core/middleware.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import threading
 from datetime import datetime, timedelta
 
 from core.connectors import RedisConnector
@@ -145,25 +144,3 @@ class StatusMessageMiddleware:
             if status:
                 self._show_message(status, request, redis_key)
                 break
-
-
-log_request_data = threading.local()
-
-
-class LogMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        log_request_data.url = request.path
-        log_request_data.user_id = request.user.ident_cely if request.user.is_authenticated else None
-        response = self.get_response(request)
-        return response
-
-    @staticmethod
-    def get_request_url():
-        return getattr(log_request_data, "url", None)
-
-    @staticmethod
-    def get_user_id():
-        return getattr(log_request_data, "user_id", None)

--- a/webclient/webclient/settings/base.py
+++ b/webclient/webclient/settings/base.py
@@ -200,7 +200,7 @@ MIDDLEWARE = [
     "core.middleware.PermissionMiddleware",
     "core.middleware.ErrorMiddleware",
     "core.middleware.StatusMessageMiddleware",
-    "core.middleware.LogMiddleware",
+    "core.log_middleware.LogMiddleware",
 ]
 
 CRON_CLASSES = [


### PR DESCRIPTION
#2604
Místo #2888 bych navrhoval rozpojit ten kruh v jiném místě, protože ta chyba se vyskytla, protože hesla_dynamicka potřebovala logovat chybu a middleware.py začal importovat další závislosti. Takto si myslím, že do budoucnosti lépe zabráníme dalším krohovým importům způsobeným hesla_dynamicka.