### PR TITLE
Duplicitní kontrola před archivací

### DIFF
--- a/webclient/arch_z/models.py
+++ b/webclient/arch_z/models.py
@@ -283,12 +283,6 @@ class ArcheologickyZaznam(ExportModelOperationsMixin("archeologicky_zaznam"), Mo
                     + str(dj.ident_cely)
                     + _("arch_z.models.ArcheologickyZaznam.checkPredArchivaci.dj.text2")
                 )
-            elif dj.pian is None:
-                result.append(
-                    _("arch_z.models.ArcheologickyZaznam.checkPredArchivaci.dj.no_pian.text1")
-                    + str(dj.ident_cely)
-                    + _("arch_z.models.ArcheologickyZaznam.checkPredArchivaci.dj.no_pian.text2")
-                )
         result = [str(x) for x in result]
         return result
 


### PR DESCRIPTION
Při archivaci akce nebo lokality bez pianu se zobrazovala 2x podobná varovná hláška, že akce nemá pian. Kontrola proběhne už na řádce 243.