### PR TITLE
Oprava kontroly EPSG při importu pianu

### DIFF
--- a/webclient/core/utils.py
+++ b/webclient/core/utils.py
@@ -41,9 +41,9 @@ class CannotFindCadasterCentre(Exception):
 
 
 def file_validate_epsg(epsg):
-    if epsg == "4326" or epsg == 4326:
+    if epsg == "4326":
         return True
-    elif epsg == "5514" or epsg == 5514:
+    elif epsg == "5514":
         return True
     else:
         return False
@@ -69,7 +69,7 @@ def validate_and_split_geometry(geom):
     """
 
     valid_bbox = "5, 40, 25, 60"
-    if geom.iloc[1] == 5514:
+    if geom.iloc[1] == "5514":
         valid_bbox = "-905000, -1230000, -400000, -930000"
     new_rows = []
     if not isinstance(geom.iloc[2], str) or geom.iloc[2] == "":

--- a/webclient/pian/views.py
+++ b/webclient/pian/views.py
@@ -404,7 +404,7 @@ class ImportovatPianView(LoginRequiredMixin, TemplateView):
             logger.debug("pian.views.ImportovatPianView.post.label_check.fileEmpty")
             return HttpResponseBadRequest(_("pian.views.importovatPianView.check.fileEmpty."))
         try:
-            sheet = pd.read_csv(docfile, sep=",")
+            sheet = pd.read_csv(docfile, sep=",", dtype=str)
         except ValueError as err:
             logger.debug("pian.views.ImportovatPianView.post.label_check.unreadable_or_empty", extra={"error": err})
             return HttpResponseBadRequest(_("pian.views.importovatPianView.check.unreadable_or_empty."))


### PR DESCRIPTION
#3181 
Při importu Pianu pokud bylo EPSG jako desetinné číslo, tak prošlo prvotní kontrolou, ale do databáze se jako desetinné číslo zapsat nedalo.