### PR TITLE
Potential fix for code scanning alert no. 110: Failure to use secure cookies

### DIFF
--- a/webclient/adb/views.py
+++ b/webclient/adb/views.py
@@ -174,6 +174,7 @@ def smazat_vb(request, ident_cely):
             f"detail_dj_form_{vyskovy_bod.adb.dokumentacni_jednotka.ident_cely}",
             max_age=1000,
             secure=True,
+            httponly=True,
             samesite="Strict",
         )
         fedora_transaction.mark_transaction_as_closed()


### PR DESCRIPTION
Potential fix for [https://github.com/ARUP-CAS/aiscr-webamcr/security/code-scanning/110](https://github.com/ARUP-CAS/aiscr-webamcr/security/code-scanning/110)

To address this issue, the cookie should be set with the `httponly=True` parameter to prevent access from JavaScript and mitigate XSS risks. This change should be made by adding the `httponly=True` argument to the call to `response.set_cookie` at line 172. No extra imports or utility methods are needed, as this is a Django built-in.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
