### PR TITLE
Oprava nastavení debug logování Fedory

### DIFF
--- a/docker-compose-dev-local-db-all-containers.yml
+++ b/docker-compose-dev-local-db-all-containers.yml
@@ -241,7 +241,7 @@ services:
     environment:
       - UMASK=002
       - TOMCAT_USERS_FILE=/var/run/secrets/tomcat_users
-      - CATALINA_OPTS="-Dfcrepo.config.file=/opt/fcrepo/conf/fcrepo.properties"
+      - JAVA_TOOL_OPTIONS=-Dfcrepo.config.file=/opt/fcrepo/conf/fcrepo.properties -Dfcrepo.log=DEBUG
     container_name: fcrepo
     logging:
       driver: "json-file"    

--- a/fedora/conf/fcrepo.properties
+++ b/fedora/conf/fcrepo.properties
@@ -3,6 +3,4 @@ fcrepo.db.url=jdbc:postgresql://host.docker.internal:5434/fcrepo
 fcrepo.db.user=fcrepo
 fcrepo.db.password=localdbpass1
 fcrepo.metrics.enable=true
-fcrepo.log=DEBUG
-fcrepo.log.auth=DEBUG
 fcrepo.session.timeout=3600000


### PR DESCRIPTION
#3444 
Teprve s tímto nastavením mi začala Fedora do logu vypisovat debug hlášky. Log je daleko detailnější, před tím byla jen úroveň INFO. Můžeme nastavit na dev a test.
https://wiki.lyrasis.org/display/FEDORA6x/Logging
