### PR TITLE
Oprava nastavení lokální testovací Fedory

### DIFF
--- a/fedora/conf/fcrepo.properties
+++ b/fedora/conf/fcrepo.properties
@@ -1,5 +1,5 @@
 fcrepo.home=/opt/fcrepo/fcrepo-home
-fcrepo.db.url=jdbc:postgresql://host.docker.internal:5434/fcrepo
+fcrepo.db.url=jdbc:postgresql://fcrepo-postgres:5432/fcrepo
 fcrepo.db.user=fcrepo
 fcrepo.db.password=localdbpass1
 fcrepo.metrics.enable=true


### PR DESCRIPTION
Funguje i staré nastavení, ale Windows mi občas rezervuje port 5434 a já ho nemůžu použít, takto je to vyřešeno pomocí vnitřního názvu Dockeru.