### PR TITLE
Nastavení délky uchování dat Prometheus

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -186,7 +186,7 @@ services:
       - prometheus_config
     command:
       - "--config.file=/run/secrets/prometheus_config"
-      - "--storage.tsdb.retention.time=365d"
+      - "--storage.tsdb.retention.time=${PROM_RETENTION_TIME:-365d}"
       - "--web.enable-admin-api"
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       - prometheus_config
     command:
       - "--config.file=/run/secrets/prometheus_config"
-      - "--storage.tsdb.retention.time=365d"
+      - "--storage.tsdb.retention.time=${PROM_RETENTION_TIME:-365d}"
       - "--web.enable-admin-api"
 
   logstash:

--- a/git_docker-compose.yml
+++ b/git_docker-compose.yml
@@ -164,7 +164,7 @@ services:
       - prometheus_config
     command:
       - "--config.file=/run/secrets/prometheus_config"
-      - "--storage.tsdb.retention.time=365d"
+      - "--storage.tsdb.retention.time=${PROM_RETENTION_TIME:-365d}"
       - "--web.enable-admin-api"
 
   logstash:


### PR DESCRIPTION
Umožní pomocí proměnné systému PROM_RETENTION_TIME nastavit délku uchování dat v Prometheovi. Pokud proměnná není nastavená, nastaví se na 365 dní.