### PR TITLE
Pokračování lokalizace komentářů a doplnění docstringů v několika modulech

### DIFF
--- a/docs/generate_module_docs.py
+++ b/docs/generate_module_docs.py
@@ -47,7 +47,7 @@ SKIP_DIRS = {"static", "templates", "locale", "__pycache__", "services"}
 # Sleduje, zda došlo ke změně souborů.
 changes_detected = False
 
-# Common file type descriptions
+# Běžné popisy typů souborů
 FILE_TYPE_INFO = {
     "models.py": {"suffix": "modely", "description": "Definice modelů."},
     "forms.py": {"suffix": "formuláře", "description": "Definice formulářů."},
@@ -1717,7 +1717,7 @@ def generate_index_rst(module_dir_name: str, generated_files: List[str], output_
         if f not in sorted_files:
             sorted_files.append(f)
 
-    # Create toctree entries (without .py extension)
+    # Vytvoří položky toctree (bez přípony .py)
     toctree_entries = [f.replace(".py", "") for f in sorted_files]
 
     # Module display name

--- a/docs/licenses/convert_to_rst.py
+++ b/docs/licenses/convert_to_rst.py
@@ -1,3 +1,5 @@
+"""Generuje RST tabulku Python závislostí z výstupu nástroje pip-licenses."""
+
 import json
 import subprocess
 
@@ -7,6 +9,7 @@ LICENSES_MANUAL_FIXES = {
 
 
 def csv_to_rst_table():
+    """Načte licence knihoven a zapíše je do dokumentace ve formátu RST."""
     output = subprocess.run(
         ["pip-licenses", "--format=json", "--with-urls", "--from=mixed", "--with-system"],
         capture_output=True,
@@ -35,7 +38,7 @@ def csv_to_rst_table():
     content = content.replace("@licence_table", rest_table_data)
     with open("docs/source/12_zavislosti/python_knihovny.rst", "w", encoding="utf-8") as rst_file:
         rst_file.write(content)
-    print(f"{len(data_to_write)} libraries written to file 'docs/source/12_zavislosti/python_knihovny.rst'.")
+    print(f"Do souboru 'docs/source/12_zavislosti/python_knihovny.rst' bylo zapsáno {len(data_to_write)} knihoven.")
 
 
 csv_to_rst_table()

--- a/fedora/fedora-init.py
+++ b/fedora/fedora-init.py
@@ -1,3 +1,9 @@
+"""Inicializace základní struktury repozitáře Fedora pro AMČR instance.
+
+Skript vytváří základní kontejnery, ACL pravidla a schéma metadat
+pro produkční i testovací prostředí.
+"""
+
 import os
 import time
 import xml.etree.ElementTree as ET
@@ -6,6 +12,7 @@ import requests
 
 
 def get_password():
+    """Načte heslo uživatele `fedoraAdmin` ze souboru se secrets."""
     soubor_xml = "/var/run/secrets/tomcat_users"
     strom = ET.parse(soubor_xml)
     root = strom.getroot()
@@ -24,6 +31,7 @@ AUTH = requests.auth.HTTPBasicAuth("fedoraAdmin", PASSWORD)
 
 
 def create_new_transaction():
+    """Založí novou transakci ve Fedora API a vrátí její URL."""
     print("create_new_transaction")
     response = requests.post(API_URL + "/fcr:tx", auth=AUTH, timeout=10)
     print(response)
@@ -31,12 +39,14 @@ def create_new_transaction():
 
 
 def commit(Atomic_ID):
+    """Potvrdí (commitne) otevřenou Fedora transakci."""
     print("commit")
     response = requests.put(Atomic_ID, auth=AUTH, timeout=10)
     print(response)
 
 
 def create_container(Atomic_ID, name, path=""):
+    """Vytvoří LDP kontejner v zadané cestě a vrátí jeho URL."""
     print("create container ", name)
     headers = {
         "Atomic-ID": Atomic_ID,
@@ -48,9 +58,8 @@ def create_container(Atomic_ID, name, path=""):
     return response.headers["link"].split(";")[0][1:-1]
 
 
-# (FedoraAcl) PUT acl resource 'AMCR/'
-# curl -u fedoraAdmin:pswd -H"Atomic-ID: http://localhost:8080/rest/fcr:tx/285ba3a5-7bce-48e0-b4a8-324da8a42a22" -X PUT http://localhost:8080/rest/AMCR/fcr:acl -H "Content-Type: text/turtle" --data-binary "@C:\Users\havrlant\Documents\ARUP\fedora\inputs\acl\repo.ttl"
 def createFedoraWebacAcl(container_path, Atomic_ID, file):
+    """Nahraje ACL definici ve formátu Turtle do kontejneru Fedora."""
     print("createFedoraWebacAcl")
     headers = {"Atomic-ID": Atomic_ID, "Content-Type": "text/turtle"}
     with open(file, "r") as f:
@@ -60,8 +69,8 @@ def createFedoraWebacAcl(container_path, Atomic_ID, file):
     print(response)
 
 
-# curl -u fedoraAdmin:pswd -H"Atomic-ID: http://localhost:8080/rest/fcr:tx/9afcc89d-7c5a-4bf8-91bd-4daa89b0c4eb" -X PUT --upload-file "C:/Users\havrlant\Documents\ARUP\fedora\inputs\amcr.xsd" -H "Content-Type: application/xml" -H "Content-Disposition: attachment; filename=\"amcr.xsd\"" -H "digest: sha-512=6ca8eca77bec25b701212d655b5c8d7aa582acbdfa72e7491f116d8e902b3ae0ecaa5dd8ca60cb06d57b5b5bcc7d887382f5e57d788f3928921d3ea04d10c4e7" "http://localhost:8080/rest/AMCR/metadata-schema"
 def upload_file(Atomic_ID, file, type, path):
+    """Nahraje binární soubor na zadanou cestu ve Fedora repozitáři."""
     print("upload_file")
     with open(file, "rb") as f:
         data = f.read()
@@ -75,6 +84,7 @@ def upload_file(Atomic_ID, file, type, path):
 
 
 def IndirectContainer(container_path, Atomic_ID, name, file):
+    """Vytvoří nepřímý LDP kontejner z Turtle šablony."""
     print("IndirectContainer")
     with open(file, "r") as f:
         data = f.read()
@@ -90,6 +100,7 @@ def IndirectContainer(container_path, Atomic_ID, name, file):
 
 
 def get_container_content(container_path):
+    """Vrátí HTTP status a seznam členů (`ldp:contains`) kontejneru."""
     headers = {}
     response = requests.get(container_path, auth=AUTH, headers=headers, timeout=10)
     members = []
@@ -105,20 +116,20 @@ def get_container_content(container_path):
     return response.status_code, members
 
 
-# 'C-202401979'
-
-
 def delete_container(container_path):
+    """Odstraní zadaný kontejner."""
     response = requests.delete(container_path, auth=AUTH, timeout=10)
     print(response.text)
 
 
 def purge_container(container_path):
+    """Odstraní tombstone po předchozím smazání kontejneru."""
     response = requests.delete(container_path + "/fcr:tombstone", auth=AUTH, timeout=10)
     print(response.text)
 
 
 def wipe_Fedora():
+    """Smaže obsah hlavních model/record větví a vyčistí tombstones."""
     code, mem = get_container_content(f"{API_URL}/{FEDORA_SERVER_NAME}/model")
     for item in mem:
         items = get_container_content(item + "/member")
@@ -133,6 +144,7 @@ def wipe_Fedora():
 
 
 def generate_base_struct():
+    """Vytvoří kompletní základní adresářovou a ACL strukturu AMČR."""
     path = os.path.dirname(__file__)
     transaction_id = create_new_transaction()
     createFedoraWebacAcl(API_URL, transaction_id, os.path.join(path, "inputs/acl/root-authorization.ttl"))
@@ -216,10 +228,11 @@ def generate_base_struct():
 
 
 def inicialize_base_directory():
-    for attempt in range(MAX_RETRIES + 1):  # Pokusíme se max_retries + 1 krát (včetně prvního pokusu)
+    """Inicializuje kořenovou strukturu repozitáře po startu služby."""
+    for attempt in range(MAX_RETRIES + 1):  # Pokusíme se `MAX_RETRIES + 1`krát (včetně prvního pokusu).
         try:
             stat, res = get_container_content(f"{API_URL}/{FEDORA_SERVER_NAME}")
-            # Pokud server odpoví status kódem 200, je vše v pořádku
+            # Pokud server odpoví kódem 200, základní struktura již existuje.
             print(f"stat {stat}")
             if stat == 503:
                 time.sleep(RETRY_DELAY)
@@ -232,7 +245,7 @@ def inicialize_base_directory():
                 generate_base_struct()
                 break
         except requests.exceptions.RequestException as e:
-            # Pokud dojde k výjimce, vypíše chybu a počká 2 sekundy před dalším pokusem
+            # Při chybě spojení vypíše detail problému a čeká před dalším pokusem.
             print(f"fedora-init.py: Chyba při pokusu o spojení s Fedorou na adrese {API_URL}/{FEDORA_SERVER_NAME}: {e}")
             if attempt < MAX_RETRIES:
                 print(f"fedora-init.py: Opakuji pokus {attempt + 1} za {RETRY_DELAY} sekund...")

--- a/webclient/core/management/commands/check_pian_properties.py
+++ b/webclient/core/management/commands/check_pian_properties.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
 
         logger.debug("core.management.commands.check_pian_properties.start")
 
-        # Prepare geometry type mapping
+        # Připraví mapování tříd geometrií na odpovídající heslářové hodnoty typu.
         geom_type = {}
         geom_type[str(Point)] = Heslar.objects.get(id=GEOMETRY_BOD)
         geom_type[str(LineString)] = Heslar.objects.get(id=GEOMETRY_LINIE)
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             changes = []
             geom = item.geom
 
-            # Check geometry type
+            # Ověří, zda uložený typ odpovídá skutečnému typu geometrie.
             if item.typ.pk != geom_type[str(type(geom))].pk:
                 old_typ = str(item.typ)
                 item.typ = geom_type[str(type(geom))]

--- a/webclient/core/management/commands/remove_gps_data.py
+++ b/webclient/core/management/commands/remove_gps_data.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         from uzivatel.models import User
         from xml_generator.models import ModelWithMetadata
 
-        # Get admin user
+        # Načte administrátorského uživatele pro systémové změny.
         try:
             admin_user = User.objects.get(pk=ADMIN_USER)
         except User.DoesNotExist:
@@ -76,7 +76,7 @@ class Command(BaseCommand):
             )
             return
 
-        # Read CSV file
+        # Načte vstupní CSV se seznamem dokumentů.
         try:
             sheet = pd.read_csv(csv_file, sep=",")
         except Exception as e:

--- a/webclient/core/utils.py
+++ b/webclient/core/utils.py
@@ -926,7 +926,7 @@ def find_pos_with_backup(lang, project_apps=True, django_apps=False, third_party
     else:
         # Pokud je `settings.SETTINGS_MODULE` None, pravděpodobně běží testovací režim.
         # a bylo použito `override_settings()`.
-        # see: https://code.djangoproject.com/ticket/25911
+        # Viz: https://code.djangoproject.com/ticket/25911
         parts = os.environ.get(ENVIRONMENT_VARIABLE).split(".")
     project = __import__(parts[0], {}, {}, [])
     abs_project_path = os.path.normpath(os.path.abspath(os.path.dirname(project.__file__)))
@@ -939,7 +939,7 @@ def find_pos_with_backup(lang, project_apps=True, django_apps=False, third_party
     case_sensitive_file_system = True
     tmphandle, tmppath = tempfile.mkstemp()
     if os.path.exists(tmppath.upper()):
-        # Case insensitive file system.
+        # Souborový systém nerozlišuje velikost písmen.
         case_sensitive_file_system = False
 
     # django/locale

--- a/webclient/core/views.py
+++ b/webclient/core/views.py
@@ -1752,7 +1752,7 @@ class RosettaFileLevelMixinWithBackup(RosettaFileLevelMixin):
 
 class TranslationImportView(FormView, RosettaFileLevelMixinWithBackup):
     """
-    Třída pohledu pro import prekladových souboru.
+    Třída pohledu pro import překladových souborů.
     """
 
     template_name = "rosetta/import_form.html"
@@ -1770,7 +1770,7 @@ class TranslationImportView(FormView, RosettaFileLevelMixinWithBackup):
             tmp.flush()
             tmp.close()
             po_file = pofile(tmp_path)
-            # remove temp file once polib has loaded it
+            # Dočasný soubor smaže až po načtení obsahu knihovnou polib.
             try:
                 os.unlink(tmp_path)
             except Exception:

--- a/webclient/projekt/views.py
+++ b/webclient/projekt/views.py
@@ -931,7 +931,7 @@ def uzavrit(request, ident_cely):
         projekt.save()
         return JsonResponse({"redirect": reverse("projekt:detail", kwargs={"ident_cely": ident_cely})})
     else:
-        # Check business rules
+        # Ověří obchodní pravidla před uzavřením projektu.
         warnings = projekt.check_pred_uzavrenim()
         logger.debug("projekt.views.uzavrit.warnings", extra={"warning": str(warnings)})
         form_check = CheckStavNotChangedForm(initial={"old_stav": projekt.stav})

--- a/webclient/uzivatel/models.py
+++ b/webclient/uzivatel/models.py
@@ -200,7 +200,7 @@ class User(ExportModelOperationsMixin("user"), AbstractBaseUser, PermissionsMixi
                 moje_spolupracujici_organizace.append(self.organizace)
             return moje_spolupracujici_organizace
         elif self.hlavni_role == archivar_group or self.hlavni_role == admin_group:
-            # Admin a archivar spolupracuje defaultne se vsemi organizacemi
+            # Admin a archivář standardně spolupracují se všemi organizacemi.
             return Organizace.objects.all()
 
     def moje_stavy_pruzkumnych_projektu(self):
@@ -211,7 +211,7 @@ class User(ExportModelOperationsMixin("user"), AbstractBaseUser, PermissionsMixi
         if self.hlavni_role == badatel_group or self.hlavni_role == archeolog_group:
             return (PROJEKT_STAV_UKONCENY_V_TERENU, PROJEKT_STAV_ZAHAJENY_V_TERENU)
         elif self.hlavni_role == archivar_group or self.hlavni_role == admin_group:
-            # Admin a archivar vidi na vsechny stavy projektu
+            # Admin a archivář vidí všechny stavy projektu.
             return (
                 PROJEKT_STAV_ARCHIVOVANY,
                 PROJEKT_STAV_NAVRZEN_KE_ZRUSENI,


### PR DESCRIPTION
### Motivation
- Zlepšit čitelnost a konzistenci kódu přeložením anglických komentářů a opravou drobných překlepů v docstringu tak, aby interní dokumentace byla v češtině. 
- Doplnit chybějící modulové a funkční docstringy u skriptů (zejména inicializační skript pro Fedora) pro lepší orientaci a údržbu.

### Description
- Přeloženy a upraveny komentáře/docstringy v `docs/generate_module_docs.py` a `docs/licenses/convert_to_rst.py`, včetně přidání modulového docstringu a lokalizovaného výstupu pro generování RST tabulky závislostí. 
- Doplněn modulový docstring a funkční docstringy u více funkcí v `fedora/fedora-init.py` a upraveny vysvětlující komentáře (bez změny obchodní logiky). 
- Počeštěny komentáře a opraveny formulace v řadě webclient modulů: `webclient/core/views.py`, `webclient/core/utils.py`, `webclient/core/management/commands/check_pian_properties.py`, `webclient/core/management/commands/remove_gps_data.py`, `webclient/projekt/views.py` a `webclient/uzivatel/models.py`. 
- Změny jsou dokumentační (komentáře/docstringy/uživatelské hlášky) a nezměnily funkční chování aplikace.

### Testing
- Spuštěno `python -m py_compile webclient/core/views.py webclient/core/utils.py webclient/core/management/commands/check_pian_properties.py webclient/core/management/commands/remove_gps_data.py webclient/projekt/views.py webclient/uzivatel/models.py` a kontrola proběhla úspěšně (soubory jsou syntakticky validní).
- Ověřeno, že skripty pro generování dokumentace a Fedora iniciaci mají čitelnější komentáře a lokalizované uživatelské výstupy (funkční testy nejsou potřeba, protože nebyla změněna obchodní logika).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69978ce3906c8325aa328a4f86210b8c)