### PR TITLE
Revert Django migration files to match test branch

### DIFF
--- a/webclient/adb/migrations/0001_initial.py
+++ b/webclient/adb/migrations/0001_initial.py
@@ -8,10 +8,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.adb.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/adb/migrations/0002_initial.py
+++ b/webclient/adb/migrations/0002_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.adb.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/adb/migrations/0003_initial.py
+++ b/webclient/adb/migrations/0003_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.adb.migrations.0003_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/adb/migrations/0004_alter_vyskovybod_options.py
+++ b/webclient/adb/migrations/0004_alter_vyskovybod_options.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.adb.migrations.0004_alter_vyskovybod_options`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("adb", "0003_initial"),
     ]

--- a/webclient/adb/migrations/0005_alter_adb_ident_cely_alter_adb_rok_popisu_and_more.py
+++ b/webclient/adb/migrations/0005_alter_adb_ident_cely_alter_adb_rok_popisu_and_more.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.adb.migrations.0005_alter_adb_ident_cely_alter_adb_rok_popisu_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("adb", "0004_alter_vyskovybod_options"),
     ]

--- a/webclient/adb/migrations/0006_alter_adb_ident_cely.py
+++ b/webclient/adb/migrations/0006_alter_adb_ident_cely.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.adb.migrations.0006_alter_adb_ident_cely`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('adb', '0005_alter_adb_ident_cely_alter_adb_rok_popisu_and_more'),
     ]

--- a/webclient/arch_z/migrations/0001_initial.py
+++ b/webclient/arch_z/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/arch_z/migrations/0002_initial.py
+++ b/webclient/arch_z/migrations/0002_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/arch_z/migrations/0003_archeologickyzaznamkatastr_katastr.py
+++ b/webclient/arch_z/migrations/0003_archeologickyzaznamkatastr_katastr.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0003_archeologickyzaznamkatastr_katastr`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/arch_z/migrations/0004_initial.py
+++ b/webclient/arch_z/migrations/0004_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0004_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/arch_z/migrations/0005_initial.py
+++ b/webclient/arch_z/migrations/0005_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0005_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/arch_z/migrations/0006_triggers.py
+++ b/webclient/arch_z/migrations/0006_triggers.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0006_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/arch_z/migrations/0007_default.py
+++ b/webclient/arch_z/migrations/0007_default.py
@@ -7,10 +7,6 @@ from django_add_default_value import AddDefaultValue
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0007_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/arch_z/migrations/0008_alter_akce_typ.py
+++ b/webclient/arch_z/migrations/0008_alter_akce_typ.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0008_alter_akce_typ`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0007_default"),
     ]

--- a/webclient/arch_z/migrations/0009_lokalitasekvence_and_more.py
+++ b/webclient/arch_z/migrations/0009_lokalitasekvence_and_more.py
@@ -7,10 +7,6 @@ from core.constants import OBLAST_CECHY, OBLAST_MORAVA
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0009_lokalitasekvence_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0003_default"),
         ("arch_z", "0008_alter_akce_typ"),

--- a/webclient/arch_z/migrations/0010_akcesekvence_akcesekvence_unique_sekvence_akce.py
+++ b/webclient/arch_z/migrations/0010_akcesekvence_akcesekvence_unique_sekvence_akce.py
@@ -6,10 +6,6 @@ from core.constants import OBLAST_CECHY, OBLAST_MORAVA
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0010_akcesekvence_akcesekvence_unique_sekvence_akce`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0009_lokalitasekvence_and_more"),
     ]

--- a/webclient/arch_z/migrations/0011_alter_akcevedouci_options.py
+++ b/webclient/arch_z/migrations/0011_alter_akcevedouci_options.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0011_alter_akcevedouci_options`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0010_akcesekvence_akcesekvence_unique_sekvence_akce"),
     ]

--- a/webclient/arch_z/migrations/0012_akce_vedouci_snapshot_alter_archeologickyzaznam_stav.py
+++ b/webclient/arch_z/migrations/0012_akce_vedouci_snapshot_alter_archeologickyzaznam_stav.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0012_akce_vedouci_snapshot_alter_archeologickyzaznam_stav`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0011_alter_akcevedouci_options"),
     ]

--- a/webclient/arch_z/migrations/0013_alter_akce_datum_ukonceni_alter_akce_datum_zahajeni_and_more.py
+++ b/webclient/arch_z/migrations/0013_alter_akce_datum_ukonceni_alter_akce_datum_zahajeni_and_more.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0013_alter_akce_datum_ukonceni_alter_akce_datum_zahajeni_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0012_akce_vedouci_snapshot_alter_archeologickyzaznam_stav"),
     ]

--- a/webclient/arch_z/migrations/0014_alter_archeologickyzaznam_typ_zaznamu.py
+++ b/webclient/arch_z/migrations/0014_alter_archeologickyzaznam_typ_zaznamu.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0014_alter_archeologickyzaznam_typ_zaznamu`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0013_alter_akce_datum_ukonceni_alter_akce_datum_zahajeni_and_more"),
     ]

--- a/webclient/arch_z/migrations/0015_alter_archeologickyzaznam_unique_together.py
+++ b/webclient/arch_z/migrations/0015_alter_archeologickyzaznam_unique_together.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0015_alter_archeologickyzaznam_unique_together`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("historie", "0008_alter_historie_datum_zmeny_alter_historie_poznamka"),
         ("arch_z", "0014_alter_archeologickyzaznam_typ_zaznamu"),

--- a/webclient/arch_z/migrations/0016_alter_akce_je_nz_alter_akce_odlozena_nz_and_more.py
+++ b/webclient/arch_z/migrations/0016_alter_akce_je_nz_alter_akce_odlozena_nz_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0016_alter_akce_je_nz_alter_akce_odlozena_nz_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0015_alter_archeologickyzaznam_unique_together"),
     ]

--- a/webclient/arch_z/migrations/0017_archeologickyzaznam_archeologic_hlavni__e8b941_idx_and_more.py
+++ b/webclient/arch_z/migrations/0017_archeologickyzaznam_archeologic_hlavni__e8b941_idx_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0017_archeologickyzaznam_archeologic_hlavni__e8b941_idx_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0016_alter_akce_je_nz_alter_akce_odlozena_nz_and_more"),
     ]

--- a/webclient/arch_z/migrations/0018_akce_akce_archeol_75782e_idx_and_more.py
+++ b/webclient/arch_z/migrations/0018_akce_akce_archeol_75782e_idx_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0018_akce_akce_archeol_75782e_idx_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0017_archeologickyzaznam_archeologic_hlavni__e8b941_idx_and_more"),
         ("heslar", "0007_alter_heslar_unique_together_and_more"),

--- a/webclient/arch_z/migrations/0019_archeologickyzaznam_archeologic_hlavni__edb4d6_idx.py
+++ b/webclient/arch_z/migrations/0019_archeologickyzaznam_archeologic_hlavni__edb4d6_idx.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.arch_z.migrations.0019_archeologickyzaznam_archeologic_hlavni__edb4d6_idx`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0018_akce_akce_archeol_75782e_idx_and_more"),
         ("heslar", "0009_alter_heslar_razeni"),

--- a/webclient/core/migrations/0001_initial.py
+++ b/webclient/core/migrations/0001_initial.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/core/migrations/0002_initial.py
+++ b/webclient/core/migrations/0002_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/core/migrations/0003_geom_functions.py
+++ b/webclient/core/migrations/0003_geom_functions.py
@@ -4,10 +4,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0003_geom_functions`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/core/migrations/0004_default.py
+++ b/webclient/core/migrations/0004_default.py
@@ -4,10 +4,6 @@ from django_add_default_value import AddDefaultValue, NOW
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0004_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/core/migrations/0005_triggers.py
+++ b/webclient/core/migrations/0005_triggers.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0005_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/core/migrations/0006_permissions.py
+++ b/webclient/core/migrations/0006_permissions.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0006_permissions`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/core/migrations/0007_soubor_mimetype_idx.py
+++ b/webclient/core/migrations/0007_soubor_mimetype_idx.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0007_soubor_mimetype_idx`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("core", "0006_permissions"),
     ]

--- a/webclient/core/migrations/0008_alter_soubor_mimetype.py
+++ b/webclient/core/migrations/0008_alter_soubor_mimetype.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0008_alter_soubor_mimetype`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("core", "0007_soubor_mimetype_idx"),
     ]

--- a/webclient/core/migrations/0009_ident_sequences_v2.py
+++ b/webclient/core/migrations/0009_ident_sequences_v2.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0009_ident_sequences_v2`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     replaces = [
         ("core", "0009_ident_sequences"),
         ("core", "0010_rename_rada_projektsekvence_region_and_more"),

--- a/webclient/core/migrations/0009_soubor_repository_uuid.py
+++ b/webclient/core/migrations/0009_soubor_repository_uuid.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0009_soubor_repository_uuid`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("core", "0008_alter_soubor_mimetype"),
     ]

--- a/webclient/core/migrations/0010_alter_soubor_path.py
+++ b/webclient/core/migrations/0010_alter_soubor_path.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0010_alter_soubor_path`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("core", "0009_soubor_repository_uuid"),
     ]

--- a/webclient/core/migrations/0011_merge_0009_ident_sequences_v2_0010_alter_soubor_path.py
+++ b/webclient/core/migrations/0011_merge_0009_ident_sequences_v2_0010_alter_soubor_path.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0011_merge_0009_ident_sequences_v2_0010_alter_soubor_path`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("core", "0009_ident_sequences_v2"),
         ("core", "0010_alter_soubor_path"),

--- a/webclient/core/migrations/0012_customadminsettings_alter_odstavkasystemu_options_and_more.py
+++ b/webclient/core/migrations/0012_customadminsettings_alter_odstavkasystemu_options_and_more.py
@@ -5,10 +5,6 @@ import django_prometheus.models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0012_customadminsettings_alter_odstavkasystemu_options_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("core", "0011_merge_0009_ident_sequences_v2_0010_alter_soubor_path"),
     ]

--- a/webclient/core/migrations/0013_alter_soubor_options_permissions.py
+++ b/webclient/core/migrations/0013_alter_soubor_options_permissions.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0013_alter_soubor_options_permissions`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("auth", "0012_alter_user_first_name_max_length"),
         ("core", "0012_customadminsettings_alter_odstavkasystemu_options_and_more"),

--- a/webclient/core/migrations/0014_permissions_action.py
+++ b/webclient/core/migrations/0014_permissions_action.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0014_permissions_action`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("core", "0013_alter_soubor_options_permissions"),
     ]

--- a/webclient/core/migrations/0015_alter_permissions_accessibility_and_more.py
+++ b/webclient/core/migrations/0015_alter_permissions_accessibility_and_more.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0015_alter_permissions_accessibility_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("core", "0014_permissions_action"),

--- a/webclient/core/migrations/0016_alter_customadminsettings_options_and_more.py
+++ b/webclient/core/migrations/0016_alter_customadminsettings_options_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0016_alter_customadminsettings_options_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0015_alter_permissions_accessibility_and_more'),
     ]

--- a/webclient/core/migrations/0017_insert_customadminsettings.py
+++ b/webclient/core/migrations/0017_insert_customadminsettings.py
@@ -5,14 +5,6 @@ except ImportError:
     from core.models import CustomAdminSettings 
 
 def insert_customadminsettings_heslar_group(apps, schema_editor):
-    """Funkce `insert_customadminsettings_heslar_group` v modulu `webclient.core.migrations.0017_insert_customadminsettings`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     CustomAdminSettings.objects.create(
         item_group='constants',
         item_id='heslar_group',
@@ -89,14 +81,6 @@ def insert_customadminsettings_heslar_group(apps, schema_editor):
     )
 
 def insert_customadminsettings_heslar(apps, schema_editor):
-    """Funkce `insert_customadminsettings_heslar` v modulu `webclient.core.migrations.0017_insert_customadminsettings`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     CustomAdminSettings.objects.create(
         item_group='constants',
         item_id='heslar',
@@ -201,10 +185,6 @@ def insert_customadminsettings_heslar(apps, schema_editor):
     )
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0017_insert_customadminsettings`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0016_alter_customadminsettings_options_and_more'),
     ]

--- a/webclient/core/migrations/0018_insert_custom_admin_settings_user.py
+++ b/webclient/core/migrations/0018_insert_custom_admin_settings_user.py
@@ -7,14 +7,6 @@ except ImportError:
 
 
 def insert_customadminsettings_heslar_group(apps, schema_editor):
-    """Funkce `insert_customadminsettings_heslar_group` v modulu `webclient.core.migrations.0018_insert_custom_admin_settings_user`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     CustomAdminSettings.objects.create(
         item_group='constants',
         item_id='user',
@@ -28,10 +20,6 @@ def insert_customadminsettings_heslar_group(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.core.migrations.0018_insert_custom_admin_settings_user`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0017_insert_customadminsettings'),
     ]

--- a/webclient/core/migrations/0019_alter_permissions_action.py
+++ b/webclient/core/migrations/0019_alter_permissions_action.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0019_alter_permissions_action`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0018_insert_custom_admin_settings_user'),
     ]

--- a/webclient/core/migrations/0020_delete_geommigrationjob_and_more.py
+++ b/webclient/core/migrations/0020_delete_geommigrationjob_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0020_delete_geommigrationjob_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0019_alter_permissions_action'),
     ]

--- a/webclient/core/migrations/0021_alter_permissions_action.py
+++ b/webclient/core/migrations/0021_alter_permissions_action.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0021_alter_permissions_action`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0020_delete_geommigrationjob_and_more'),
     ]

--- a/webclient/core/migrations/0022_geom_functions.py
+++ b/webclient/core/migrations/0022_geom_functions.py
@@ -4,10 +4,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0022_geom_functions`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/core/migrations/0023_alter_permissions_action.py
+++ b/webclient/core/migrations/0023_alter_permissions_action.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0023_alter_permissions_action`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0022_geom_functions'),
     ]

--- a/webclient/core/migrations/0024_alter_permissions_action.py
+++ b/webclient/core/migrations/0024_alter_permissions_action.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.core.migrations.0024_alter_permissions_action`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0023_alter_permissions_action'),
     ]

--- a/webclient/dj/migrations/0001_initial.py
+++ b/webclient/dj/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dj.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dj/migrations/0002_dokumentacnijednotka_komponenty.py
+++ b/webclient/dj/migrations/0002_dokumentacnijednotka_komponenty.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dj.migrations.0002_dokumentacnijednotka_komponenty`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dj/migrations/0003_initial.py
+++ b/webclient/dj/migrations/0003_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dj.migrations.0003_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dj/migrations/0004_triggers.py
+++ b/webclient/dj/migrations/0004_triggers.py
@@ -2,10 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.dj.migrations.0004_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dj/migrations/0005_default.py
+++ b/webclient/dj/migrations/0005_default.py
@@ -3,10 +3,6 @@ from django_add_default_value import AddDefaultValue
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.dj.migrations.0005_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dj/migrations/0006_alter_dokumentacnijednotka_negativni_jednotka.py
+++ b/webclient/dj/migrations/0006_alter_dokumentacnijednotka_negativni_jednotka.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dj.migrations.0006_alter_dokumentacnijednotka_negativni_jednotka`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dj", "0005_default"),
     ]

--- a/webclient/dokument/migrations/0001_initial.py
+++ b/webclient/dokument/migrations/0001_initial.py
@@ -8,10 +8,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dokument/migrations/0002_initial.py
+++ b/webclient/dokument/migrations/0002_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dokument/migrations/0003_initial.py
+++ b/webclient/dokument/migrations/0003_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0003_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dokument/migrations/0004_triggers.py
+++ b/webclient/dokument/migrations/0004_triggers.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0004_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/dokument/migrations/0005_alter_dokumentautor_options.py
+++ b/webclient/dokument/migrations/0005_alter_dokumentautor_options.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0005_alter_dokumentautor_options`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0004_triggers"),
     ]

--- a/webclient/dokument/migrations/0006_uprava_dokumentsekvence.py
+++ b/webclient/dokument/migrations/0006_uprava_dokumentsekvence.py
@@ -8,10 +8,6 @@ from core.constants import OBLAST_CECHY, OBLAST_MORAVA
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0006_uprava_dokumentsekvence`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0003_default"),
         ("dokument", "0005_alter_dokumentautor_options"),

--- a/webclient/dokument/migrations/0007_alter_dokumentautor_options_alter_let_options.py
+++ b/webclient/dokument/migrations/0007_alter_dokumentautor_options_alter_let_options.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0007_alter_dokumentautor_options_alter_let_options`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0006_uprava_dokumentsekvence"),
     ]

--- a/webclient/dokument/migrations/0008_alter_tvar_options.py
+++ b/webclient/dokument/migrations/0008_alter_tvar_options.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0008_alter_tvar_options`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0007_alter_dokumentautor_options_alter_let_options"),
     ]

--- a/webclient/dokument/migrations/0009_alter_dokumentextradata_region_and_more.py
+++ b/webclient/dokument/migrations/0009_alter_dokumentextradata_region_and_more.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0009_alter_dokumentextradata_region_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
         ("dokument", "0008_alter_tvar_options"),

--- a/webclient/dokument/migrations/0010_alter_dokumentextradata_region_and_more.py
+++ b/webclient/dokument/migrations/0010_alter_dokumentextradata_region_and_more.py
@@ -7,10 +7,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0010_alter_dokumentextradata_region_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
         ("dokument", "0009_alter_dokumentextradata_region_and_more"),

--- a/webclient/dokument/migrations/0011_rename_region_dokumentextradata_region_extra_and_more.py
+++ b/webclient/dokument/migrations/0011_rename_region_dokumentextradata_region_extra_and_more.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0011_rename_region_dokumentextradata_region_extra_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
         ("dokument", "0010_alter_dokumentextradata_region_and_more"),

--- a/webclient/dokument/migrations/0012_alter_dokument_options_and_more.py
+++ b/webclient/dokument/migrations/0012_alter_dokument_options_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0012_alter_dokument_options_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("arch_z", "0017_archeologickyzaznam_archeologic_hlavni__e8b941_idx_and_more"),
         ("dokument", "0011_rename_region_dokumentextradata_region_extra_and_more"),

--- a/webclient/dokument/migrations/0013_dokument_doi_alter_dokument_jazyky_and_more.py
+++ b/webclient/dokument/migrations/0013_dokument_doi_alter_dokument_jazyky_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0013_dokument_doi_alter_dokument_jazyky_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0012_alter_dokument_options_and_more"),
         ("heslar", "0008_heslarodkaz_scheme_uri"),

--- a/webclient/dokument/migrations/0013_dokumentextradata_geom_sjtsk_and_more.py
+++ b/webclient/dokument/migrations/0013_dokumentextradata_geom_sjtsk_and_more.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0013_dokumentextradata_geom_sjtsk_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0012_alter_dokument_options_and_more"),
     ]

--- a/webclient/dokument/migrations/0014_merge_20250112_1542.py
+++ b/webclient/dokument/migrations/0014_merge_20250112_1542.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0014_merge_20250112_1542`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0013_dokument_doi_alter_dokument_jazyky_and_more"),
         ("dokument", "0013_dokumentextradata_geom_sjtsk_and_more"),

--- a/webclient/dokument/migrations/0015_alter_dokument_doi_alter_dokument_jazyky_and_more.py
+++ b/webclient/dokument/migrations/0015_alter_dokument_doi_alter_dokument_jazyky_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0015_alter_dokument_doi_alter_dokument_jazyky_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0014_merge_20250112_1542"),
         ("heslar", "0009_alter_heslar_razeni"),

--- a/webclient/dokument/migrations/0016_alter_dokument_jazyky_alter_dokument_posudky.py
+++ b/webclient/dokument/migrations/0016_alter_dokument_jazyky_alter_dokument_posudky.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0016_alter_dokument_jazyky_alter_dokument_posudky`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('dokument', '0015_alter_dokument_doi_alter_dokument_jazyky_and_more'),
         ('heslar', '0009_alter_heslar_razeni'),

--- a/webclient/dokument/migrations/0017_alter_tvar_tvar.py
+++ b/webclient/dokument/migrations/0017_alter_tvar_tvar.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.dokument.migrations.0017_alter_tvar_tvar`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("dokument", "0016_alter_dokument_jazyky_alter_dokument_posudky"),
         ("heslar", "0011_ruiankraj_email"),

--- a/webclient/ez/migrations/0001_initial.py
+++ b/webclient/ez/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.ez.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/ez/migrations/0002_externizdroj_historie.py
+++ b/webclient/ez/migrations/0002_externizdroj_historie.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.ez.migrations.0002_externizdroj_historie`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/ez/migrations/0003_initial.py
+++ b/webclient/ez/migrations/0003_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.ez.migrations.0003_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/ez/migrations/0004_externizdrojsekvence_and_more.py
+++ b/webclient/ez/migrations/0004_externizdrojsekvence_and_more.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.ez.migrations.0004_externizdrojsekvence_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("ez", "0003_initial"),
     ]

--- a/webclient/ez/migrations/0005_change_organizace_field_type.py
+++ b/webclient/ez/migrations/0005_change_organizace_field_type.py
@@ -3,10 +3,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.ez.migrations.0005_change_organizace_field_type`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('ez', '0004_externizdrojsekvence_and_more'),
     ]

--- a/webclient/ez/migrations/0006_externizdroj_organizace_nazev_and_more.py
+++ b/webclient/ez/migrations/0006_externizdroj_organizace_nazev_and_more.py
@@ -4,14 +4,6 @@ from django.db import migrations, models
 
 
 def populate_organizace_nazev(apps, schema_editor):
-    """Funkce `populate_organizace_nazev` v modulu `webclient.ez.migrations.0006_externizdroj_organizace_nazev_and_more`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     ExterniZdroj = apps.get_model('ez', 'ExterniZdroj')
     for instance in ExterniZdroj.objects.all():
         if instance.organizace:
@@ -21,10 +13,6 @@ def populate_organizace_nazev(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.ez.migrations.0006_externizdroj_organizace_nazev_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("ez", "0005_change_organizace_field_type"),
     ]

--- a/webclient/ez/migrations/0007_remove_externizdroj_organizace_nazev_and_more.py
+++ b/webclient/ez/migrations/0007_remove_externizdroj_organizace_nazev_and_more.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.ez.migrations.0007_remove_externizdroj_organizace_nazev_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("ez", "0006_externizdroj_organizace_nazev_and_more"),
     ]

--- a/webclient/ez/migrations/0008_rename_organizace_nazev_externizdroj_organizace.py
+++ b/webclient/ez/migrations/0008_rename_organizace_nazev_externizdroj_organizace.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.ez.migrations.0008_rename_organizace_nazev_externizdroj_organizace`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("ez", "0007_remove_externizdroj_organizace_nazev_and_more"),
     ]

--- a/webclient/ez/migrations/0009_alter_externizdroj_datum_rd.py
+++ b/webclient/ez/migrations/0009_alter_externizdroj_datum_rd.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.ez.migrations.0009_alter_externizdroj_datum_rd`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("ez", "0008_rename_organizace_nazev_externizdroj_organizace"),
     ]

--- a/webclient/ez/migrations/0010_externizdroj_doi.py
+++ b/webclient/ez/migrations/0010_externizdroj_doi.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.ez.migrations.0010_externizdroj_doi`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("ez", "0009_alter_externizdroj_datum_rd"),
     ]

--- a/webclient/ez/migrations/0011_alter_externizdroj_doi.py
+++ b/webclient/ez/migrations/0011_alter_externizdroj_doi.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.ez.migrations.0011_alter_externizdroj_doi`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("ez", "0010_externizdroj_doi"),
     ]

--- a/webclient/heslar/migrations/0001_initial.py
+++ b/webclient/heslar/migrations/0001_initial.py
@@ -8,10 +8,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/heslar/migrations/0002_initial.py
+++ b/webclient/heslar/migrations/0002_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/heslar/migrations/0003_default.py
+++ b/webclient/heslar/migrations/0003_default.py
@@ -5,10 +5,6 @@ from core.constants import PROJEKT_STAV_OZNAMENY, CESKY, ORGANIZACE_MESICU_DO_ZV
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0003_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/heslar/migrations/0004_alter_ruiankatastr_kod_alter_ruiankatastr_nazev.py
+++ b/webclient/heslar/migrations/0004_alter_ruiankatastr_kod_alter_ruiankatastr_nazev.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0004_alter_ruiankatastr_kod_alter_ruiankatastr_nazev`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0003_default"),
     ]

--- a/webclient/heslar/migrations/0005_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more.py
+++ b/webclient/heslar/migrations/0005_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0005_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0004_alter_ruiankatastr_kod_alter_ruiankatastr_nazev"),
     ]

--- a/webclient/heslar/migrations/0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more.py
+++ b/webclient/heslar/migrations/0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0005_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
     ]

--- a/webclient/heslar/migrations/0007_alter_heslar_unique_together_and_more.py
+++ b/webclient/heslar/migrations/0007_alter_heslar_unique_together_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0007_alter_heslar_unique_together_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
     ]

--- a/webclient/heslar/migrations/0008_heslarodkaz_scheme_uri.py
+++ b/webclient/heslar/migrations/0008_heslarodkaz_scheme_uri.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0008_heslarodkaz_scheme_uri`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0007_alter_heslar_unique_together_and_more"),
     ]

--- a/webclient/heslar/migrations/0009_alter_heslar_razeni.py
+++ b/webclient/heslar/migrations/0009_alter_heslar_razeni.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0009_alter_heslar_razeni`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0008_heslarodkaz_scheme_uri"),
     ]

--- a/webclient/heslar/migrations/0010_alter_heslar_razeni.py
+++ b/webclient/heslar/migrations/0010_alter_heslar_razeni.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0010_alter_heslar_razeni`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('heslar', '0009_alter_heslar_razeni'),
     ]

--- a/webclient/heslar/migrations/0011_ruiankraj_email.py
+++ b/webclient/heslar/migrations/0011_ruiankraj_email.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.heslar.migrations.0011_ruiankraj_email`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('heslar', '0010_alter_heslar_razeni'),
     ]

--- a/webclient/historie/migrations/0001_initial.py
+++ b/webclient/historie/migrations/0001_initial.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.historie.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/historie/migrations/0002_initial.py
+++ b/webclient/historie/migrations/0002_initial.py
@@ -7,10 +7,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.historie.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/historie/migrations/0003_triggers.py
+++ b/webclient/historie/migrations/0003_triggers.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.historie.migrations.0003_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/historie/migrations/0004_alter_historie_options.py
+++ b/webclient/historie/migrations/0004_alter_historie_options.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.historie.migrations.0004_alter_historie_options`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("historie", "0003_triggers"),
     ]

--- a/webclient/historie/migrations/0005_alter_historie_typ_zmeny.py
+++ b/webclient/historie/migrations/0005_alter_historie_typ_zmeny.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.historie.migrations.0005_alter_historie_typ_zmeny`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("historie", "0004_alter_historie_options"),
     ]

--- a/webclient/historie/migrations/0006_alter_historie_datum_zmeny_alter_historie_poznamka_and_more.py
+++ b/webclient/historie/migrations/0006_alter_historie_datum_zmeny_alter_historie_poznamka_and_more.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.historie.migrations.0006_alter_historie_datum_zmeny_alter_historie_poznamka_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("historie", "0005_alter_historie_typ_zmeny"),

--- a/webclient/historie/migrations/0007_historie_organizace_snapshot_and_more.py
+++ b/webclient/historie/migrations/0007_historie_organizace_snapshot_and_more.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.historie.migrations.0007_historie_organizace_snapshot_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0009_alter_historicaluser_telefon_alter_user_telefon_and_more"),
         (

--- a/webclient/historie/migrations/0008_alter_historie_datum_zmeny_alter_historie_poznamka.py
+++ b/webclient/historie/migrations/0008_alter_historie_datum_zmeny_alter_historie_poznamka.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.historie.migrations.0008_alter_historie_datum_zmeny_alter_historie_poznamka`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("historie", "0007_historie_organizace_snapshot_and_more"),
     ]

--- a/webclient/historie/migrations/0009_alter_historie_typ_zmeny.py
+++ b/webclient/historie/migrations/0009_alter_historie_typ_zmeny.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.historie.migrations.0009_alter_historie_typ_zmeny`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('historie', '0008_alter_historie_datum_zmeny_alter_historie_poznamka'),
     ]

--- a/webclient/historie/migrations/0010_historie_historie_org_lookup_idx.py
+++ b/webclient/historie/migrations/0010_historie_historie_org_lookup_idx.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.historie.migrations.0010_historie_historie_org_lookup_idx`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('historie', '0009_alter_historie_typ_zmeny'),
         ('uzivatel', '0027_add_notifikace_typ_E-P-11'),

--- a/webclient/komponenta/migrations/0001_initial.py
+++ b/webclient/komponenta/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.komponenta.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/komponenta/migrations/0002_triggers.py
+++ b/webclient/komponenta/migrations/0002_triggers.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.komponenta.migrations.0002_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/lokalita/migrations/0001_initial.py
+++ b/webclient/lokalita/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.lokalita.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/lokalita/migrations/0002_lokalita_igsn.py
+++ b/webclient/lokalita/migrations/0002_lokalita_igsn.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.lokalita.migrations.0002_lokalita_igsn`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("lokalita", "0001_initial"),
     ]

--- a/webclient/lokalita/migrations/0003_alter_lokalita_igsn.py
+++ b/webclient/lokalita/migrations/0003_alter_lokalita_igsn.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.lokalita.migrations.0003_alter_lokalita_igsn`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('lokalita', '0002_lokalita_igsn'),
     ]

--- a/webclient/nalez/migrations/0001_initial.py
+++ b/webclient/nalez/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.nalez.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/nalez/migrations/0002_alter_nalezobjekt_druh_alter_nalezobjekt_specifikace_and_more.py
+++ b/webclient/nalez/migrations/0002_alter_nalezobjekt_druh_alter_nalezobjekt_specifikace_and_more.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.nalez.migrations.0002_alter_nalezobjekt_druh_alter_nalezobjekt_specifikace_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0005_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
         ("nalez", "0001_initial"),

--- a/webclient/nalez/migrations/0003_alter_nalezobjekt_options_alter_nalezpredmet_options.py
+++ b/webclient/nalez/migrations/0003_alter_nalezobjekt_options_alter_nalezpredmet_options.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.nalez.migrations.0003_alter_nalezobjekt_options_alter_nalezpredmet_options`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("nalez", "0002_alter_nalezobjekt_druh_alter_nalezobjekt_specifikace_and_more"),
     ]

--- a/webclient/nalez/migrations/0004_alter_nalezobjekt_druh_alter_nalezobjekt_pocet_and_more.py
+++ b/webclient/nalez/migrations/0004_alter_nalezobjekt_druh_alter_nalezobjekt_pocet_and_more.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.nalez.migrations.0004_alter_nalezobjekt_druh_alter_nalezobjekt_pocet_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0007_alter_heslar_unique_together_and_more"),
         ("nalez", "0003_alter_nalezobjekt_options_alter_nalezpredmet_options"),

--- a/webclient/neidentakce/migrations/0001_initial.py
+++ b/webclient/neidentakce/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.neidentakce.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/neidentakce/migrations/0002_initial.py
+++ b/webclient/neidentakce/migrations/0002_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.neidentakce.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/neidentakce/migrations/0003_auto_20230328_1612.py
+++ b/webclient/neidentakce/migrations/0003_auto_20230328_1612.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.neidentakce.migrations.0003_auto_20230328_1612`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('neidentakce', '0002_initial'),
     ]

--- a/webclient/neidentakce/migrations/0004_alter_neidentakcevedouci_neident_akce.py
+++ b/webclient/neidentakce/migrations/0004_alter_neidentakcevedouci_neident_akce.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.neidentakce.migrations.0004_alter_neidentakcevedouci_neident_akce`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("neidentakce", "0003_auto_20230328_1612"),
     ]

--- a/webclient/notifikace_projekty/migrations/0001_initial.py
+++ b/webclient/notifikace_projekty/migrations/0001_initial.py
@@ -7,10 +7,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.notifikace_projekty.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/oznameni/migrations/0001_initial.py
+++ b/webclient/oznameni/migrations/0001_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.oznameni.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/oznameni/migrations/0002_oznamovatel_poznamka.py
+++ b/webclient/oznameni/migrations/0002_oznamovatel_poznamka.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.oznameni.migrations.0002_oznamovatel_poznamka`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("oznameni", "0001_initial"),
     ]

--- a/webclient/pas/migrations/0001_initial.py
+++ b/webclient/pas/migrations/0001_initial.py
@@ -7,10 +7,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pas/migrations/0002_initial.py
+++ b/webclient/pas/migrations/0002_initial.py
@@ -7,10 +7,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pas/migrations/0003_default.py
+++ b/webclient/pas/migrations/0003_default.py
@@ -3,10 +3,6 @@ from django_add_default_value import AddDefaultValue
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.pas.migrations.0003_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pas/migrations/0004_triggers.py
+++ b/webclient/pas/migrations/0004_triggers.py
@@ -4,10 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.pas.migrations.0004_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pas/migrations/0005_alter_samostatnynalez_projekt.py
+++ b/webclient/pas/migrations/0005_alter_samostatnynalez_projekt.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.pas.migrations.0005_alter_samostatnynalez_projekt`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("projekt", "0006_alter_projekt_stav"),
         ("pas", "0004_triggers"),

--- a/webclient/pas/migrations/0006_views.py
+++ b/webclient/pas/migrations/0006_views.py
@@ -3,10 +3,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0006_views`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pas/migrations/0007_remove_samostatnynalez_samostatny_nalez_geom_check_and_more.py
+++ b/webclient/pas/migrations/0007_remove_samostatnynalez_samostatny_nalez_geom_check_and_more.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0007_remove_samostatnynalez_samostatny_nalez_geom_check_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('core', '0016_alter_customadminsettings_options_and_more'),
         ('heslar', '0007_alter_heslar_unique_together_and_more'),

--- a/webclient/pas/migrations/0008_remove_samostatnynalez_geom_sjtsk_updated_at_and_more.py
+++ b/webclient/pas/migrations/0008_remove_samostatnynalez_geom_sjtsk_updated_at_and_more.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0008_remove_samostatnynalez_geom_sjtsk_updated_at_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('pas', '0007_remove_samostatnynalez_samostatny_nalez_geom_check_and_more'),
     ]

--- a/webclient/pas/migrations/0008_samostatnynalez_igsn_alter_samostatnynalez_projekt.py
+++ b/webclient/pas/migrations/0008_samostatnynalez_igsn_alter_samostatnynalez_projekt.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0008_samostatnynalez_igsn_alter_samostatnynalez_projekt`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("pas", "0007_remove_samostatnynalez_samostatny_nalez_geom_check_and_more"),
         ("projekt", "0008_alter_projekt_datum_ukonceni_and_more"),

--- a/webclient/pas/migrations/0009_merge_20250112_1542.py
+++ b/webclient/pas/migrations/0009_merge_20250112_1542.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0009_merge_20250112_1542`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("pas", "0008_remove_samostatnynalez_geom_sjtsk_updated_at_and_more"),
         ("pas", "0008_samostatnynalez_igsn_alter_samostatnynalez_projekt"),

--- a/webclient/pas/migrations/0010_alter_samostatnynalez_igsn_and_more.py
+++ b/webclient/pas/migrations/0010_alter_samostatnynalez_igsn_and_more.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0010_alter_samostatnynalez_igsn_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("pas", "0009_merge_20250112_1542"),
     ]

--- a/webclient/pas/migrations/0011_alter_samostatnynalez_projekt.py
+++ b/webclient/pas/migrations/0011_alter_samostatnynalez_projekt.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pas.migrations.0011_alter_samostatnynalez_projekt`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('pas', '0010_alter_samostatnynalez_igsn_and_more'),
         ('projekt', '0010_projekt_pristupnost_snapshot'),

--- a/webclient/pian/migrations/0001_initial.py
+++ b/webclient/pian/migrations/0001_initial.py
@@ -7,10 +7,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pian.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pian/migrations/0002_default.py
+++ b/webclient/pian/migrations/0002_default.py
@@ -5,10 +5,6 @@ from core.constants import PIAN_NEPOTVRZEN
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.pian.migrations.0002_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pian/migrations/0003_views.py
+++ b/webclient/pian/migrations/0003_views.py
@@ -3,10 +3,6 @@ from django.db import migrations,models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pian.migrations.0003_views`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pian/migrations/0004_alter_piansekvence_unique_together_and_more.py
+++ b/webclient/pian/migrations/0004_alter_piansekvence_unique_together_and_more.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.pian.migrations.0004_alter_piansekvence_unique_together_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("pian", "0003_views"),
     ]

--- a/webclient/pian/migrations/0005_views.py
+++ b/webclient/pian/migrations/0005_views.py
@@ -3,10 +3,6 @@ from django.db import migrations,models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pian.migrations.0005_views`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/pian/migrations/0006_remove_pian_pian_geom_check_alter_pian_geom_system_and_more.py
+++ b/webclient/pian/migrations/0006_remove_pian_pian_geom_check_alter_pian_geom_system_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pian.migrations.0006_remove_pian_pian_geom_check_alter_pian_geom_system_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('heslar', '0007_alter_heslar_unique_together_and_more'),
         ('historie', '0009_alter_historie_typ_zmeny'),

--- a/webclient/pian/migrations/0007_remove_pian_geom_sjtsk_updated_at_and_more.py
+++ b/webclient/pian/migrations/0007_remove_pian_geom_sjtsk_updated_at_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.pian.migrations.0007_remove_pian_geom_sjtsk_updated_at_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('pian', '0006_remove_pian_pian_geom_check_alter_pian_geom_system_and_more'),
     ]

--- a/webclient/projekt/migrations/0001_initial.py
+++ b/webclient/projekt/migrations/0001_initial.py
@@ -8,10 +8,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/projekt/migrations/0002_initial.py
+++ b/webclient/projekt/migrations/0002_initial.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0002_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/projekt/migrations/0003_triggers.py
+++ b/webclient/projekt/migrations/0003_triggers.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0003_triggers`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/projekt/migrations/0004_default.py
+++ b/webclient/projekt/migrations/0004_default.py
@@ -5,10 +5,6 @@ from core.constants import  PROJEKT_STAV_OZNAMENY
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0004_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/projekt/migrations/0005_views.py
+++ b/webclient/projekt/migrations/0005_views.py
@@ -3,10 +3,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0005_views`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/projekt/migrations/0006_alter_projekt_stav.py
+++ b/webclient/projekt/migrations/0006_alter_projekt_stav.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0006_alter_projekt_stav`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("projekt", "0005_views"),
     ]

--- a/webclient/projekt/migrations/0007_alter_projekt_typ_projektu.py
+++ b/webclient/projekt/migrations/0007_alter_projekt_typ_projektu.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0007_alter_projekt_typ_projektu`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0005_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
         ("projekt", "0006_alter_projekt_stav"),

--- a/webclient/projekt/migrations/0008_alter_projekt_datum_ukonceni_and_more.py
+++ b/webclient/projekt/migrations/0008_alter_projekt_datum_ukonceni_and_more.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0008_alter_projekt_datum_ukonceni_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("heslar", "0006_alter_heslar_ident_cely_alter_heslardatace_obdobi_and_more"),
         ("uzivatel", "0008_alter_usernotificationtype_options_and_more"),

--- a/webclient/projekt/migrations/0009_projekt_geom_sjtsk_projekt_geom_system.py
+++ b/webclient/projekt/migrations/0009_projekt_geom_sjtsk_projekt_geom_system.py
@@ -6,10 +6,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0009_projekt_geom_sjtsk_projekt_geom_system`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("projekt", "0008_alter_projekt_datum_ukonceni_and_more"),
     ]

--- a/webclient/projekt/migrations/0010_projekt_pristupnost_snapshot.py
+++ b/webclient/projekt/migrations/0010_projekt_pristupnost_snapshot.py
@@ -4,10 +4,6 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.projekt.migrations.0010_projekt_pristupnost_snapshot`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     atomic = False
 
     dependencies = [

--- a/webclient/uzivatel/migrations/0001_initial.py
+++ b/webclient/uzivatel/migrations/0001_initial.py
@@ -16,10 +16,6 @@ from core.constants import ORGANIZACE_MESICU_DO_ZVEREJNENI_MAX
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0001_initial`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/uzivatel/migrations/0002_default.py
+++ b/webclient/uzivatel/migrations/0002_default.py
@@ -5,10 +5,6 @@ from core.constants import PROJEKT_STAV_OZNAMENY, CESKY, ORGANIZACE_MESICU_DO_ZV
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0002_default`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     initial = True
 
     dependencies = [

--- a/webclient/uzivatel/migrations/0003_alter_historicaluser_options_and_more.py
+++ b/webclient/uzivatel/migrations/0003_alter_historicaluser_options_and_more.py
@@ -5,10 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0003_alter_historicaluser_options_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("historie", "0003_triggers"),
         ("uzivatel", "0002_default"),

--- a/webclient/uzivatel/migrations/0004_alter_osoba_vypis_cely.py
+++ b/webclient/uzivatel/migrations/0004_alter_osoba_vypis_cely.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0004_alter_osoba_vypis_cely`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0003_alter_historicaluser_options_and_more"),
     ]

--- a/webclient/uzivatel/migrations/0005_alter_auth_user_groups_id.py
+++ b/webclient/uzivatel/migrations/0005_alter_auth_user_groups_id.py
@@ -3,10 +3,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0005_alter_auth_user_groups_id`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('uzivatel', '0004_alter_osoba_vypis_cely'),
     ]

--- a/webclient/uzivatel/migrations/0006_remove_notificationslog_notifikace__content_009350_idx_and_more.py
+++ b/webclient/uzivatel/migrations/0006_remove_notificationslog_notifikace__content_009350_idx_and_more.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0006_remove_notificationslog_notifikace__content_009350_idx_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0005_alter_auth_user_groups_id"),
     ]

--- a/webclient/uzivatel/migrations/0007_usernotificationtype_text_cs_and_more.py
+++ b/webclient/uzivatel/migrations/0007_usernotificationtype_text_cs_and_more.py
@@ -4,10 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0007_usernotificationtype_text_cs_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         (
             "uzivatel",

--- a/webclient/uzivatel/migrations/0008_alter_usernotificationtype_options_and_more.py
+++ b/webclient/uzivatel/migrations/0008_alter_usernotificationtype_options_and_more.py
@@ -6,10 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0008_alter_usernotificationtype_options_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0007_usernotificationtype_text_cs_and_more"),
     ]

--- a/webclient/uzivatel/migrations/0009_alter_historicaluser_telefon_alter_user_telefon_and_more.py
+++ b/webclient/uzivatel/migrations/0009_alter_historicaluser_telefon_alter_user_telefon_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0009_alter_historicaluser_telefon_alter_user_telefon_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0008_alter_usernotificationtype_options_and_more"),
     ]

--- a/webclient/uzivatel/migrations/0010_alter_historicaluser_first_name_and_more.py
+++ b/webclient/uzivatel/migrations/0010_alter_historicaluser_first_name_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0010_alter_historicaluser_first_name_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0009_alter_historicaluser_telefon_alter_user_telefon_and_more"),
     ]

--- a/webclient/uzivatel/migrations/0011_notificationslog_exception_notificationslog_status.py
+++ b/webclient/uzivatel/migrations/0011_notificationslog_exception_notificationslog_status.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0011_notificationslog_exception_notificationslog_status`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0010_alter_historicaluser_first_name_and_more"),
     ]

--- a/webclient/uzivatel/migrations/0012_delete_historicaluser.py
+++ b/webclient/uzivatel/migrations/0012_delete_historicaluser.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0012_delete_historicaluser`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0011_notificationslog_exception_notificationslog_status"),
     ]

--- a/webclient/uzivatel/migrations/0013_uzivatelprihlasenilog.py
+++ b/webclient/uzivatel/migrations/0013_uzivatelprihlasenilog.py
@@ -7,10 +7,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0013_uzivatelprihlasenilog`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0012_delete_historicaluser"),
     ]

--- a/webclient/uzivatel/migrations/0014_rename_ip_address_uzivatelprihlasenilog_ip_adresa_and_more.py
+++ b/webclient/uzivatel/migrations/0014_rename_ip_address_uzivatelprihlasenilog_ip_adresa_and_more.py
@@ -5,10 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0014_rename_ip_address_uzivatelprihlasenilog_ip_adresa_and_more`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0013_uzivatelprihlasenilog"),
     ]

--- a/webclient/uzivatel/migrations/0015_alter_user_jazyk.py
+++ b/webclient/uzivatel/migrations/0015_alter_user_jazyk.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0015_alter_user_jazyk`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0014_rename_ip_address_uzivatelprihlasenilog_ip_adresa_and_more"),
     ]

--- a/webclient/uzivatel/migrations/0016_organizace_cteni_dokumentu.py
+++ b/webclient/uzivatel/migrations/0016_organizace_cteni_dokumentu.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0016_organizace_cteni_dokumentu`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0015_alter_user_jazyk"),
     ]

--- a/webclient/uzivatel/migrations/0017_osoba_orcid_osoba_wikidata.py
+++ b/webclient/uzivatel/migrations/0017_osoba_orcid_osoba_wikidata.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0017_osoba_orcid_osoba_wikidata`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0016_organizace_cteni_dokumentu"),
     ]

--- a/webclient/uzivatel/migrations/0018_organizace_ror.py
+++ b/webclient/uzivatel/migrations/0018_organizace_ror.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0018_organizace_ror`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0017_osoba_orcid_osoba_wikidata"),
     ]

--- a/webclient/uzivatel/migrations/0019_alter_osoba_orcid.py
+++ b/webclient/uzivatel/migrations/0019_alter_osoba_orcid.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0019_alter_osoba_orcid`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0018_organizace_ror"),
     ]

--- a/webclient/uzivatel/migrations/0020_add_notifikace_typ_E-N-07.py
+++ b/webclient/uzivatel/migrations/0020_add_notifikace_typ_E-N-07.py
@@ -3,23 +3,11 @@
 from django.db import migrations, models
 
 def add_notifikace_typ(apps, schema_editor):
-    """Funkce `add_notifikace_typ` v modulu `webclient.uzivatel.migrations.0020_add_notifikace_typ_E-N-07`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     NotifikaceTyp = apps.get_model('uzivatel', 'UserNotificationType')
     NotifikaceTyp.objects.create(ident_cely='E-N-07')
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0020_add_notifikace_typ_E-N-07`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0019_alter_osoba_orcid"),
     ]

--- a/webclient/uzivatel/migrations/0021_add_notifikace_typ.py
+++ b/webclient/uzivatel/migrations/0021_add_notifikace_typ.py
@@ -1,14 +1,6 @@
 from django.db import migrations, models
 
 def add_notifikace_typ(apps, schema_editor):
-    """Funkce `add_notifikace_typ` v modulu `webclient.uzivatel.migrations.0021_add_notifikace_typ`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     NotifikaceTyp = apps.get_model('uzivatel', 'UserNotificationType')
     NotifikaceTyp.objects.get_or_create(ident_cely='S-E-P-02c')
     NotifikaceTyp.objects.get_or_create(ident_cely='S-E-P-02b')
@@ -16,10 +8,6 @@ def add_notifikace_typ(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0021_add_notifikace_typ`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0020_add_notifikace_typ_E-N-07"),
     ]

--- a/webclient/uzivatel/migrations/0022_add_notifikace_typ_zpravodaj.py
+++ b/webclient/uzivatel/migrations/0022_add_notifikace_typ_zpravodaj.py
@@ -1,23 +1,11 @@
 from django.db import migrations, models
 
 def add_notifikace_typ(apps, schema_editor):
-    """Funkce `add_notifikace_typ` v modulu `webclient.uzivatel.migrations.0022_add_notifikace_typ_zpravodaj`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     NotifikaceTyp = apps.get_model('uzivatel', 'UserNotificationType')
     NotifikaceTyp.objects.get_or_create(ident_cely='zpravodaj')
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0022_add_notifikace_typ_zpravodaj`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0021_add_notifikace_typ"),
     ]

--- a/webclient/uzivatel/migrations/0023_add_notifikace_typ_E-N-09.py
+++ b/webclient/uzivatel/migrations/0023_add_notifikace_typ_E-N-09.py
@@ -1,24 +1,12 @@
 from django.db import migrations, models
 
 def add_notifikace_typ(apps, schema_editor):
-    """Funkce `add_notifikace_typ` v modulu `webclient.uzivatel.migrations.0023_add_notifikace_typ_E-N-09`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     NotifikaceTyp = apps.get_model('uzivatel', 'UserNotificationType')
     NotifikaceTyp.objects.create(ident_cely='E-P-09')
     NotifikaceTyp.objects.create(ident_cely='E-P-10')
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0023_add_notifikace_typ_E-N-09`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0022_add_notifikace_typ_zpravodaj"),
     ]

--- a/webclient/uzivatel/migrations/0024_organizace_licence.py
+++ b/webclient/uzivatel/migrations/0024_organizace_licence.py
@@ -5,14 +5,6 @@ from django.db import migrations, models
 
 
 def set_default_licence(apps, schema_editor):
-    """Funkce `set_default_licence` v modulu `webclient.uzivatel.migrations.0024_organizace_licence`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     Organizace = apps.get_model('uzivatel', 'Organizace')
     get_default_licence = __import__('uzivatel.models', fromlist=['get_default_licence']).get_default_licence
     default_licence = get_default_licence()
@@ -21,10 +13,6 @@ def set_default_licence(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0024_organizace_licence`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('heslar', '0011_ruiankraj_email'),
         ('uzivatel', '0023_add_notifikace_typ_E-N-09'),

--- a/webclient/uzivatel/migrations/0025_organizace_web.py
+++ b/webclient/uzivatel/migrations/0025_organizace_web.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0025_organizace_web`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ('uzivatel', '0024_organizace_licence'),
     ]

--- a/webclient/uzivatel/migrations/0026_add_notifikace_typ_E-U-07.py
+++ b/webclient/uzivatel/migrations/0026_add_notifikace_typ_E-U-07.py
@@ -1,23 +1,11 @@
 from django.db import migrations, models
 
 def add_notifikace_typ(apps, schema_editor):
-    """Funkce `add_notifikace_typ` v modulu `webclient.uzivatel.migrations.0026_add_notifikace_typ_E-U-07`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     NotifikaceTyp = apps.get_model('uzivatel', 'UserNotificationType')
     NotifikaceTyp.objects.create(ident_cely='E-U-07')
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0026_add_notifikace_typ_E-U-07`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0025_organizace_web"),
     ]

--- a/webclient/uzivatel/migrations/0027_add_notifikace_typ_E-P-11.py
+++ b/webclient/uzivatel/migrations/0027_add_notifikace_typ_E-P-11.py
@@ -1,23 +1,11 @@
 from django.db import migrations, models
 
 def add_notifikace_typ(apps, schema_editor):
-    """Funkce `add_notifikace_typ` v modulu `webclient.uzivatel.migrations.0027_add_notifikace_typ_E-P-11`.
-    
-    Zajišťuje dílčí aplikační logiku pro tento modul.
-    
-    :param apps: Vstupní hodnota používaná při zpracování.
-    :param schema_editor: Vstupní hodnota používaná při zpracování.
-    :return: Výsledek odpovídající účelu volání.
-    """
     NotifikaceTyp = apps.get_model('uzivatel', 'UserNotificationType')
     NotifikaceTyp.objects.create(ident_cely='E-P-11')
 
 class Migration(migrations.Migration):
 
-    """Třída `Migration` v modulu `webclient.uzivatel.migrations.0027_add_notifikace_typ_E-P-11`.
-    
-    Zapouzdřuje související data a chování v rámci dané části aplikace.
-    """
     dependencies = [
         ("uzivatel", "0026_add_notifikace_typ_E-U-07"),
     ]


### PR DESCRIPTION
### Motivation
- Auto-generated Django migration files were edited (docstrings/comments) and should be reverted to their original autogenerated state from the `test` baseline to avoid manual changes in migrations.
- Restore ensures migrations remain machine-generated and consistent with the repository history.

### Description
- Restored all files matching `webclient/**/migrations/*.py` to the state from the repository reference commit used as the `test` baseline (`c8c02c3`), removing comment/docstring-only edits from those files.
- Only migration files were modified; no non-migration files were changed.
- Changes were committed with message `Revert Django migration files to test branch state` and the resulting commit is `a42e024`.
- A PR was created with the corresponding title/body summarizing this revert.

### Testing
- Verified the working tree and migration-only scope with `git status --short` and listing of `webclient/**/migrations/*.py` changes, which confirmed only migration files were affected (succeeded).
- Performed the restore using `git restore --source c8c02c3 -- ':(glob)webclient/**/migrations/*.py'` and committed with `git add ... && git commit -m 'Revert Django migration files to test branch state'`, resulting in commit `a42e024` (succeeded).
- Confirmed commit and PR creation with `git rev-parse --short HEAD` and `git show --name-only --pretty=format:'%h %s' --stat HEAD`, and inspected sample files with `nl` to ensure headers reverted (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a101f60c288325a3aa27e592102468)