### PR TITLE
docs: localize toctree captions and reorganize Django module documentation

### DIFF
--- a/docs/source/03_vyvoj/struktura_projektu.rst
+++ b/docs/source/03_vyvoj/struktura_projektu.rst
@@ -37,3 +37,15 @@ lokální a testovací konfigurace.
 
 
 
+
+
+Vazba dokumentace na kódovou strukturu
+------------------------------------
+
+* Modulová dokumentace pro Django aplikace je v ``docs/source/04_django_aplikace/04_02_moduly``.
+* Implementace těchto modulů je v adresářích pod ``webclient/`` (např. ``webclient/core``, ``webclient/projekt``).
+* Při přidání nové Django aplikace je potřeba doplnit:
+
+  #. položku do ``INSTALLED_APPS`` v ``webclient/webclient/settings/base.py``,
+  #. odpovídající ``index.rst`` pod ``docs/source/04_django_aplikace/04_02_moduly``,
+  #. odkaz na modul v ``docs/source/04_django_aplikace/04_02_moduly/index.rst``.

--- a/docs/source/04_django_aplikace/04_02_moduly/adb/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/adb/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu adb.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/arch_z/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/arch_z/index.rst
@@ -5,10 +5,11 @@ Dokumentace modulu arch_z.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms
+   helpers
    views
    signals
    filters

--- a/docs/source/04_django_aplikace/04_02_moduly/core/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/core/index.rst
@@ -5,10 +5,11 @@ Dokumentace modulu core.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms
+   helpers
    views
    signals
    admin

--- a/docs/source/04_django_aplikace/04_02_moduly/cron/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/cron/index.rst
@@ -5,6 +5,6 @@ Dokumentace modulu cron.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    tasks

--- a/docs/source/04_django_aplikace/04_02_moduly/dj/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/dj/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu dj.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/dokument/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/dokument/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu dokument.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/ez/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/ez/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu ez.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/fedora_management/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/fedora_management/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu fedora_management.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    forms
    views

--- a/docs/source/04_django_aplikace/04_02_moduly/healthcheck/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/healthcheck/index.rst
@@ -5,6 +5,6 @@ Dokumentace modulu healthcheck.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    views

--- a/docs/source/04_django_aplikace/04_02_moduly/heslar/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/heslar/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu heslar.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/historie/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/historie/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu historie.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    views

--- a/docs/source/04_django_aplikace/04_02_moduly/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/index.rst
@@ -1,17 +1,20 @@
 Moduly aplikace
 ==================
 
-Zde nalezneme dokumentaci kódu seřazenou podle struktury modulů projektu. Každá aplikace je definována pro správu určité funkce v projektu. 
+Tato sekce popisuje moduly Django aplikace v širším kontextu běhu systému.
+Seznam je členěn na doménové a systémové moduly podle aktuálního kódu aplikace.
+
+Doménové moduly
+---------------
 
 .. toctree::
    :maxdepth: 2
-   :caption: Moduly:
+   :caption: Obsah:
 
    adb/index
    arch_z/index
-   core/index
    dj/index
-   dokumenty/index
+   dokument/index
    ez/index
    heslar/index
    historie/index
@@ -24,6 +27,20 @@ Zde nalezneme dokumentaci kódu seřazenou podle struktury modulů projektu. Ka�
    pas/index
    pian/index
    projekt/index
+
+Systémové a integrační moduly
+-----------------------------
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Obsah:
+
+   core/index
+   cron/index
+   fedora_management/index
+   healthcheck/index
+   pid/index
    uzivatel/index
-
-
+   vypis/index
+   webclient/index
+   xml_generator/index

--- a/docs/source/04_django_aplikace/04_02_moduly/komponenta/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/komponenta/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu komponenta.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/lokalita/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/lokalita/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu lokalita.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/nalez/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/nalez/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu nalez.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/neidentakce/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/neidentakce/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu neidentakce.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/notifikace_projekty/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/notifikace_projekty/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu notifikace_projekty.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/oznameni/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/oznameni/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu oznameni.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/pas/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pas/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu pas.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/pian/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pian/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu pian.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/pid/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pid/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu pid.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    forms
    views

--- a/docs/source/04_django_aplikace/04_02_moduly/projekt/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/projekt/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu projekt.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/uzivatel/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/uzivatel/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu uzivatel.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    forms

--- a/docs/source/04_django_aplikace/04_02_moduly/vypis/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/vypis/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu vypis.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    views
    config

--- a/docs/source/04_django_aplikace/04_02_moduly/webclient/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/webclient/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu webclient.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    asgi
    celery

--- a/docs/source/04_django_aplikace/04_02_moduly/xml_generator/index.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/xml_generator/index.rst
@@ -5,7 +5,7 @@ Dokumentace modulu xml_generator.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Obsah:
 
    models
    generator

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,11 +3,11 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Technická dokumenetace Archeologické mapy České republiky (AMČR)
+Technická dokumentace Archeologické mapy České republiky (AMČR)
 ========================================
 
 Repozitář obsahuje webovou aplikaci Archeologická mapa České republiky.
-Aplikace je psaná pomocí frameworku Django a je rozdelená do funkčních modulů.
+Aplikace je psaná pomocí frameworku Django a je rozdělená do funkčních modulů.
 
 Dokumentace je rozdělena do logických sekcí pokrývajících všechny aspekty aplikace od instalace přes vývoj až po nasazení a údržbu.
 


### PR DESCRIPTION
### Motivation

- Improve Czech localization of the documentation by replacing English toctree captions and fixing minor text issues.  
- Make the Django application documentation structure clearer by separating domain modules from system/integration modules.  
- Provide explicit guidance that maps documentation modules to the codebase and document steps required when adding a new Django app.

### Description

- Replaced `:caption: Contents:` with `:caption: Obsah:` across many `docs/source/04_django_aplikace/04_02_moduly/*/index.rst` files.  
- Added missing toctree entries such as `helpers` in several module indexes and adjusted lists of subpages in multiple `index.rst` files.  
- Reworked `docs/source/04_django_aplikace/04_02_moduly/index.rst` to introduce a split between "Doménové moduly" and "Systémové a integrační moduly" and reordered/relocated several module references accordingly.  
- Added a new section "Vazba dokumentace na kódovou strukturu" to `docs/source/03_vyvoj/struktura_projektu.rst` that explains where module docs live, where implementations are under `webclient/`, and lists steps to add a new Django app (update `INSTALLED_APPS` in `webclient/webclient/settings/base.py`, add `index.rst` under `docs/source/04_django_aplikace/04_02_moduly`, and add a link in the modules index).  
- Fixed minor typos and phrasing in the top-level `docs/source/index.rst`.

### Testing

- No automated tests were modified and no CI tests were executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a105cb1f9c8325880d7690232976fa)