### PR TITLE
ci: fix propagation of warnings into pre-commit summary and PR comment

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -101,10 +101,12 @@ jobs:
           grep -Ei "warning DOC[0-9]{3}" precommit.clean.log || true
           echo "EOF" >> "$GITHUB_OUTPUT"
 
-          # Extract generic warnings from pre-commit log
-          # (without duplicating already extracted docstring warnings)
+          # Extract generic warnings from pre-commit log.
+          # Match both "warning" and shorter "warn" forms because
+          # some tools emit WARN/WARNI prefixes instead of whole word.
+          # Remove docstring warnings that are reported separately.
           echo "log_warnings<<EOF" >> "$GITHUB_OUTPUT"
-          grep -Ei "warning" precommit.clean.log \
+          grep -Ei "(::warning::|\bwarn(ing)?\b)" precommit.clean.log \
             | grep -Evi "warning DOC[0-9]{3}" \
             | sort -u || true
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -218,6 +220,19 @@ jobs:
             const runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}";
             const marker = "<!-- precommit-bot-comment -->";
       
+            const sections = [];
+            if (logWarnings && logWarnings.trim()) {
+              sections.push(`### Log warnings\n\`\`\`\n${logWarnings}\n\`\`\``);
+            }
+
+            if (docWarnings && docWarnings.trim()) {
+              sections.push(`### Docstring warnings\n\`\`\`\n${docWarnings}\n\`\`\``);
+            }
+
+            if (flakeErrors && flakeErrors.trim()) {
+              sections.push(`### Flake8 errors\n\`\`\`\n${flakeErrors}\n\`\`\``);
+            }
+
             let body = `${marker}
             ## ⚠️ Pre-commit results
             
@@ -225,41 +240,12 @@ jobs:
             - Strict mode: ${strictMode}
             - Changes detected: ${changed}
             - Workflow run: [View logs](${runUrl})
+            ${sections.join("\n\n")}
             `;
 
-            if (logWarnings && logWarnings.trim()) {
+            if (logTail && logTail.trim()) {
               body += `
 
-            ### Log warnings
-            \`\`\`
-            ${logWarnings}
-            \`\`\`
-            `;
-            }
-
-            if (docWarnings && docWarnings.trim()) {
-              body += `
-
-            ### Docstring warnings
-            \`\`\`
-            ${docWarnings}
-            \`\`\`
-            `;
-                        }
-            
-                        if (flakeErrors && flakeErrors.trim()) {
-                          body += `
-            
-            ### Flake8 errors
-            \`\`\`
-            ${flakeErrors}
-            \`\`\`
-            `;
-                        }
-            
-                        if (logTail && logTail.trim()) {
-                          body += `
-            
             <details>
             <summary>Pre-commit log (tail)</summary>
             
@@ -268,7 +254,7 @@ jobs:
             \`\`\`
             </details>
             `;
-                        }
+            }
 
             body = body.replace(/^[ \t]+/gm, '');
 


### PR DESCRIPTION
### Motivation

- The pre-commit workflow only grepped the literal `warning`, which missed variants like `WARN`/`warn` and GitHub annotations `::warning::`, causing many warnings to never be set into `steps.hooks.outputs.log_warnings` and thus not appear in the summary or PR comment.
- Ensure the same warning/docstring/flake8 information that is published to `GITHUB_STEP_SUMMARY` also appears in the sticky comment on the PR for consistent visibility.

### Description

- Updated the extraction in ` .github/workflows/pre_commit.yml` to use `(::warning::|\bwarn(ing)?\b)` so both `::warning::` and `warn`/`warning` variants are captured while still excluding docstring warnings matched by `warning DOC[0-9]{3}`.
- Refactored the PR comment generation (the `actions/github-script` step) to build a `sections` array and join it into the sticky comment, making the comment content consistent with the workflow summary.
- Added clarifying comments and minor formatting adjustments in ` .github/workflows/pre_commit.yml` to document the matching behavior.

### Testing

- `apply_patch` ran successfully and updated ` .github/workflows/pre_commit.yml`.
- `git diff --check` completed with no whitespace or diff-check errors.
- `git status --short` and the commit operation completed successfully, showing the change was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a258f45a3c832584a3c575ae54fc22)