### PR TITLE
Smazání Static root před nasazením

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -62,6 +62,10 @@ fi
 
 unset PGPASSWORD
 
+STATIC_ROOT=$(python3 manage.py shell -v 0 -c "from django.conf import settings; print(settings.STATIC_ROOT)")
+echo "Cleaning STATIC_ROOT: $STATIC_ROOT"
+find "$STATIC_ROOT" -mindepth 1 -delete
+
 python3 manage.py migrate
 python3 manage.py collectstatic --noinput
 python3 manage.py compress --force


### PR DESCRIPTION
Před novým nasazením je potřeba promazat adresář static_root, jinak může mít `python3 manage.py compress --force` problémy. 
Aktuální při přechodu na Bootstrap 5 nebo zpět.