### PR TITLE
Oprava map.spin is not a function a chyby produkčního manifestu

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,7 +44,7 @@ authors:
     orcid: "https://orcid.org/0000-0001-7050-9572"
     affiliation: "Czech Academy of Sciences, Institute of Archaeology, Brno"
 title: "Archeologická mapa České republiky"
-version: "v1.2.1-beta"
+version: "v1.2.1-beta1"
 doi: 10.5281/zenodo.8363642
 date-released: "2026-04-09"
 url: "https://github.com/ARUP-CAS/aiscr-webamcr"

--- a/docs/source/12_zavislosti/javascript_knihovny.rst
+++ b/docs/source/12_zavislosti/javascript_knihovny.rst
@@ -71,8 +71,8 @@ Knihovny instalované pomocí Node.js
      - MIT
      - https://momentjs.com
    * - spin.js
-     - 4.1.2
-     - MIT
+     - 2.3.2
+     - BSD-2-Clause
      - https://github.com/fgnass/spin.js
 
 .. END GENERATED NODEJS LIBRARIES

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "leaflet.featuregroup.subgroup": "1.0.2",
         "leaflet.markercluster": "1.5.3",
         "moment": "2.30.1",
-        "spin.js": "4.1.2"
+        "spin.js": "2.3.2"
       }
     },
     "node_modules/@popperjs/core": {
@@ -166,10 +166,10 @@
       }
     },
     "node_modules/spin.js": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/spin.js/-/spin.js-4.1.2.tgz",
-      "integrity": "sha512-ua/yEpxEwyEUWs57tMQYdik/KJ12sQRyMXjSlK/Ai927aEUDVY3FXUi4ml4VvlLCTQNIjC6tHyjSLBrJzFAqMA==",
-      "license": "MIT"
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/spin.js/-/spin.js-2.3.2.tgz",
+      "integrity": "sha512-ryhCvKCRa6J5Fxa7Y+fnhE2a+e05JwfW5dxO82zPd0uDM9o+qp8p74BJUurjiqCqmDsWNvGOAxfqdD317XIedg==",
+      "license": "BSD-2-Clause"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "leaflet.featuregroup.subgroup": "1.0.2",
     "leaflet.markercluster": "1.5.3",
     "moment": "2.30.1",
-    "spin.js": "4.1.2"
+    "spin.js": "2.3.2"
   }
 }

--- a/webclient/arch_z/templates/arch_z/detail_common.html
+++ b/webclient/arch_z/templates/arch_z/detail_common.html
@@ -12,7 +12,6 @@
       const settings_heatmap_options = {% get_settings "heatmap_options" "arch_z_heatmap_options" %};
     {% endautoescape %}
   </script>
-  <!--  <link rel="stylesheet" href="{% static 'icons/bootstrap-icons-1.5.0/bootstrap-icons.css' %}">-->
 
   <!-- Leaflet imports -->
   <link rel="stylesheet" href="{% static 'leaflet/dist/leaflet.css' %}"/>


### PR DESCRIPTION
Popis
Commit e851ddf (migrace na npm; #3430) zavedl dvě chyby:

map.spin is not a function — leaflet-spin očekává globál window.Spinner ze starého API knihovny spin.js (v1/v2). Verze 4.1.2 přidaná při npm migraci je ES modul bez globálu, leaflet-spin tedy nedokázal plugin inicializovat a metoda map.spin() nebyla dostupná. Oprava: downgrade spin.js na 2.3.2 (poslední verze s kompatibilním IIFE API, kterou leaflet-spin deklaruje jako svou závislost).

ValueError v produkci při renderování šablony — v detail_common.html zůstal zakomentovaný <link> tag se {% static %} tagem odkazujícím na icons/bootstrap-icons-1.5.0/bootstrap-icons.css. Django template engine vyhodnocuje {% static %} i uvnitř HTML komentářů. V produkci používá NonStrictManifestStaticFilesStorage, která při vyhledání neexistujícího souboru v manifestu vyvolá ValueError (a vlastní hashed_name v core/storage.py re-raisuje výjimky pro non-.map soubory). Lokálně v DEBUG=True se chyba neprojevuje, protože manifest se nepoužívá. Oprava: smazání zastaralého komentáře.

Změny
package.json, package-lock.json — downgrade spin.js 4.1.2 → 2.3.2
webclient/arch_z/templates/arch_z/detail_common.html — smazán zastaralý komentář se {% static %} tagem
docs/source/12_zavislosti/javascript_knihovny.rst — aktualizována verze a licence spin.js v dokumentaci