### PR TITLE
Ojedinělá chyba při ztrátě spojení s repozitářem

### DIFF
--- a/webclient/core/message_constants.py
+++ b/webclient/core/message_constants.py
@@ -251,3 +251,8 @@ APPLICATION_RESTART_SUCCESS: Final = _("core.message_constants.applicationRestar
 
 # uzivatel
 ZADOST_SMAZANI_UZIVATELE_SUCCESS: Final = _("core.message.ZADOST_SMAZANI_UZIVATELE_SUCCESS.text")
+
+# Fedora repozitář
+CHYBA_SPOJENI_REPOZITAR: Final = _(
+    "common.message.CHYBA_SPOJENI_REPOZITAR.text"
+)  # Operaci nelze dokončit: repozitář není dostupný. Zkuste akci opakovat za chvíli.

--- a/webclient/core/repository_connector.py
+++ b/webclient/core/repository_connector.py
@@ -576,78 +576,83 @@ INSERT DATA {{ <> dcterms:creator <info:fedora/{settings.FEDORA_SERVER_NAME}/rec
                 )
             if request_type.value < 1000:
                 self.transaction.changes_count += 1
-        try:
-            if request_type in (FedoraRequestType.CREATE_CONTAINER, FedoraRequestType.CREATE_BINARY_FILE_CONTAINER):
-                response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
-            elif request_type in (
-                FedoraRequestType.GET_CONTAINER,
-                FedoraRequestType.GET_METADATA,
-                FedoraRequestType.GET_BINARY_FILE_CONTAINER,
-                FedoraRequestType.GET_BINARY_FILE_CONTENT,
-                FedoraRequestType.GET_LINK,
-                FedoraRequestType.GET_DELETED_LINK,
-                FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB,
-                FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB_LARGE,
-                FedoraRequestType.GET_TOMBSTONE,
-                FedoraRequestType.GET_METADATA_HISTORIE,
-                FedoraRequestType.GET_BINARY_FILE_CONTENT_HISTORIE,
-            ):
-                try:
-                    response = requests.get(url, headers=headers, auth=auth, verify=False)
-                except requests.exceptions.RequestException:
-                    return None
-            elif request_type in (
-                FedoraRequestType.CREATE_METADATA,
-                FedoraRequestType.RECORD_DELETION_ADD_MARK,
-                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_4,
-                FedoraRequestType.CREATE_LINK,
-            ):
-                response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
-            elif request_type in (
-                FedoraRequestType.CREATE_BINARY_FILE_CONTENT,
-                FedoraRequestType.CREATE_BINARY_FILE_THUMB,
-                FedoraRequestType.CREATE_BINARY_FILE_THUMB_LARGE,
-            ):
-                response = requests.post(url, headers=headers, data=data, auth=auth, verify=False, timeout=10)
-            elif request_type in (
-                FedoraRequestType.UPDATE_METADATA,
-                FedoraRequestType.UPDATE_BINARY_FILE_CONTENT,
-                FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB,
-                FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB_LARGE,
-            ):
-                response = requests.put(url, headers=headers, data=data, auth=auth, verify=False)
-            elif request_type == FedoraRequestType.CREATE_BINARY_FILE:
-                response = requests.post(url, headers=headers, auth=auth, data=data, verify=False)
-            elif request_type in (
-                FedoraRequestType.DELETE_CONTAINER,
-                FedoraRequestType.DELETE_TOMBSTONE,
-                FedoraRequestType.DELETE_LINK_CONTAINER,
-                FedoraRequestType.DELETE_LINK_TOMBSTONE,
-                FedoraRequestType.DELETE_BINARY_FILE_COMPLETELY,
-                FedoraRequestType.CONNECT_DELETED_RECORD_3,
-                FedoraRequestType.CONNECT_DELETED_RECORD_4,
-                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_5,
-            ):
-                response = requests.delete(url, headers=headers, auth=auth)
-            elif request_type in (
-                FedoraRequestType.RECORD_DELETION_MOVE_MEMBERS,
-                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_2,
-                FedoraRequestType.DELETE_BINARY_FILE,
-                FedoraRequestType.CONNECT_DELETED_RECORD_1,
-                FedoraRequestType.CONNECT_DELETED_RECORD_2,
-                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_6,
-                FedoraRequestType.METADATA_UPDATE_RDF_DATA,
-                FedoraRequestType.FILE_CONTENT_UPDATE_RDF_DATA,
-                FedoraRequestType.THUMB_CONTENT_UPDATE_RDF_DATA,
-                FedoraRequestType.THUMB_LARGE_CONTENT_UPDATE_RDF_DATA,
-            ):
-                response = requests.patch(url, auth=auth, headers=headers, data=data)
-        except requests.exceptions.ConnectionError as exc:
-            logger.error(
-                "core_repository_connector._send_request.connection_error",
-                extra={"url": url, "request_type": request_type, "transaction": self.transaction_uid, "error": exc},
-            )
-            raise FedoraNoResponseError(url, str(exc), None, fedora_transaction=self.transaction)
+        if request_type in (
+            FedoraRequestType.GET_CONTAINER,
+            FedoraRequestType.GET_METADATA,
+            FedoraRequestType.GET_BINARY_FILE_CONTAINER,
+            FedoraRequestType.GET_BINARY_FILE_CONTENT,
+            FedoraRequestType.GET_LINK,
+            FedoraRequestType.GET_DELETED_LINK,
+            FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB,
+            FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB_LARGE,
+            FedoraRequestType.GET_TOMBSTONE,
+            FedoraRequestType.GET_METADATA_HISTORIE,
+            FedoraRequestType.GET_BINARY_FILE_CONTENT_HISTORIE,
+        ):
+            try:
+                response = requests.get(url, headers=headers, auth=auth, verify=False)
+            except requests.exceptions.RequestException as exc:
+                logger.warning(
+                    "core_repository_connector._send_request.get_request_failed",
+                    extra={"url": url, "request_type": request_type, "error": exc},
+                )
+                return None
+        else:
+            try:
+                if request_type in (FedoraRequestType.CREATE_CONTAINER, FedoraRequestType.CREATE_BINARY_FILE_CONTAINER):
+                    response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
+                elif request_type in (
+                    FedoraRequestType.CREATE_METADATA,
+                    FedoraRequestType.RECORD_DELETION_ADD_MARK,
+                    FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_4,
+                    FedoraRequestType.CREATE_LINK,
+                ):
+                    response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
+                elif request_type in (
+                    FedoraRequestType.CREATE_BINARY_FILE_CONTENT,
+                    FedoraRequestType.CREATE_BINARY_FILE_THUMB,
+                    FedoraRequestType.CREATE_BINARY_FILE_THUMB_LARGE,
+                ):
+                    response = requests.post(url, headers=headers, data=data, auth=auth, verify=False, timeout=10)
+                elif request_type in (
+                    FedoraRequestType.UPDATE_METADATA,
+                    FedoraRequestType.UPDATE_BINARY_FILE_CONTENT,
+                    FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB,
+                    FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB_LARGE,
+                ):
+                    response = requests.put(url, headers=headers, data=data, auth=auth, verify=False)
+                elif request_type == FedoraRequestType.CREATE_BINARY_FILE:
+                    response = requests.post(url, headers=headers, auth=auth, data=data, verify=False)
+                elif request_type in (
+                    FedoraRequestType.DELETE_CONTAINER,
+                    FedoraRequestType.DELETE_TOMBSTONE,
+                    FedoraRequestType.DELETE_LINK_CONTAINER,
+                    FedoraRequestType.DELETE_LINK_TOMBSTONE,
+                    FedoraRequestType.DELETE_BINARY_FILE_COMPLETELY,
+                    FedoraRequestType.CONNECT_DELETED_RECORD_3,
+                    FedoraRequestType.CONNECT_DELETED_RECORD_4,
+                    FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_5,
+                ):
+                    response = requests.delete(url, headers=headers, auth=auth)
+                elif request_type in (
+                    FedoraRequestType.RECORD_DELETION_MOVE_MEMBERS,
+                    FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_2,
+                    FedoraRequestType.DELETE_BINARY_FILE,
+                    FedoraRequestType.CONNECT_DELETED_RECORD_1,
+                    FedoraRequestType.CONNECT_DELETED_RECORD_2,
+                    FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_6,
+                    FedoraRequestType.METADATA_UPDATE_RDF_DATA,
+                    FedoraRequestType.FILE_CONTENT_UPDATE_RDF_DATA,
+                    FedoraRequestType.THUMB_CONTENT_UPDATE_RDF_DATA,
+                    FedoraRequestType.THUMB_LARGE_CONTENT_UPDATE_RDF_DATA,
+                ):
+                    response = requests.patch(url, auth=auth, headers=headers, data=data)
+            except requests.exceptions.ConnectionError as exc:
+                logger.error(
+                    "core_repository_connector._send_request.connection_error",
+                    extra={"url": url, "request_type": request_type, "transaction": self.transaction_uid, "error": exc},
+                )
+                raise FedoraNoResponseError(url, str(exc), None, fedora_transaction=self.transaction)
         extra["status_code"] = response.status_code
 
         if request_type in (

--- a/webclient/core/repository_connector.py
+++ b/webclient/core/repository_connector.py
@@ -576,71 +576,78 @@ INSERT DATA {{ <> dcterms:creator <info:fedora/{settings.FEDORA_SERVER_NAME}/rec
                 )
             if request_type.value < 1000:
                 self.transaction.changes_count += 1
-        if request_type in (FedoraRequestType.CREATE_CONTAINER, FedoraRequestType.CREATE_BINARY_FILE_CONTAINER):
-            response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
-        elif request_type in (
-            FedoraRequestType.GET_CONTAINER,
-            FedoraRequestType.GET_METADATA,
-            FedoraRequestType.GET_BINARY_FILE_CONTAINER,
-            FedoraRequestType.GET_BINARY_FILE_CONTENT,
-            FedoraRequestType.GET_LINK,
-            FedoraRequestType.GET_DELETED_LINK,
-            FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB,
-            FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB_LARGE,
-            FedoraRequestType.GET_TOMBSTONE,
-            FedoraRequestType.GET_METADATA_HISTORIE,
-            FedoraRequestType.GET_BINARY_FILE_CONTENT_HISTORIE,
-        ):
-            try:
-                response = requests.get(url, headers=headers, auth=auth, verify=False)
-            except requests.exceptions.RequestException:
-                return None
-        elif request_type in (
-            FedoraRequestType.CREATE_METADATA,
-            FedoraRequestType.RECORD_DELETION_ADD_MARK,
-            FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_4,
-            FedoraRequestType.CREATE_LINK,
-        ):
-            response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
-        elif request_type in (
-            FedoraRequestType.CREATE_BINARY_FILE_CONTENT,
-            FedoraRequestType.CREATE_BINARY_FILE_THUMB,
-            FedoraRequestType.CREATE_BINARY_FILE_THUMB_LARGE,
-        ):
-            response = requests.post(url, headers=headers, data=data, auth=auth, verify=False, timeout=10)
-        elif request_type in (
-            FedoraRequestType.UPDATE_METADATA,
-            FedoraRequestType.UPDATE_BINARY_FILE_CONTENT,
-            FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB,
-            FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB_LARGE,
-        ):
-            response = requests.put(url, headers=headers, data=data, auth=auth, verify=False)
-        elif request_type == FedoraRequestType.CREATE_BINARY_FILE:
-            response = requests.post(url, headers=headers, auth=auth, data=data, verify=False)
-        elif request_type in (
-            FedoraRequestType.DELETE_CONTAINER,
-            FedoraRequestType.DELETE_TOMBSTONE,
-            FedoraRequestType.DELETE_LINK_CONTAINER,
-            FedoraRequestType.DELETE_LINK_TOMBSTONE,
-            FedoraRequestType.DELETE_BINARY_FILE_COMPLETELY,
-            FedoraRequestType.CONNECT_DELETED_RECORD_3,
-            FedoraRequestType.CONNECT_DELETED_RECORD_4,
-            FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_5,
-        ):
-            response = requests.delete(url, headers=headers, auth=auth)
-        elif request_type in (
-            FedoraRequestType.RECORD_DELETION_MOVE_MEMBERS,
-            FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_2,
-            FedoraRequestType.DELETE_BINARY_FILE,
-            FedoraRequestType.CONNECT_DELETED_RECORD_1,
-            FedoraRequestType.CONNECT_DELETED_RECORD_2,
-            FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_6,
-            FedoraRequestType.METADATA_UPDATE_RDF_DATA,
-            FedoraRequestType.FILE_CONTENT_UPDATE_RDF_DATA,
-            FedoraRequestType.THUMB_CONTENT_UPDATE_RDF_DATA,
-            FedoraRequestType.THUMB_LARGE_CONTENT_UPDATE_RDF_DATA,
-        ):
-            response = requests.patch(url, auth=auth, headers=headers, data=data)
+        try:
+            if request_type in (FedoraRequestType.CREATE_CONTAINER, FedoraRequestType.CREATE_BINARY_FILE_CONTAINER):
+                response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
+            elif request_type in (
+                FedoraRequestType.GET_CONTAINER,
+                FedoraRequestType.GET_METADATA,
+                FedoraRequestType.GET_BINARY_FILE_CONTAINER,
+                FedoraRequestType.GET_BINARY_FILE_CONTENT,
+                FedoraRequestType.GET_LINK,
+                FedoraRequestType.GET_DELETED_LINK,
+                FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB,
+                FedoraRequestType.GET_BINARY_FILE_CONTENT_THUMB_LARGE,
+                FedoraRequestType.GET_TOMBSTONE,
+                FedoraRequestType.GET_METADATA_HISTORIE,
+                FedoraRequestType.GET_BINARY_FILE_CONTENT_HISTORIE,
+            ):
+                try:
+                    response = requests.get(url, headers=headers, auth=auth, verify=False)
+                except requests.exceptions.RequestException:
+                    return None
+            elif request_type in (
+                FedoraRequestType.CREATE_METADATA,
+                FedoraRequestType.RECORD_DELETION_ADD_MARK,
+                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_4,
+                FedoraRequestType.CREATE_LINK,
+            ):
+                response = requests.post(url, headers=headers, data=data, auth=auth, verify=False)
+            elif request_type in (
+                FedoraRequestType.CREATE_BINARY_FILE_CONTENT,
+                FedoraRequestType.CREATE_BINARY_FILE_THUMB,
+                FedoraRequestType.CREATE_BINARY_FILE_THUMB_LARGE,
+            ):
+                response = requests.post(url, headers=headers, data=data, auth=auth, verify=False, timeout=10)
+            elif request_type in (
+                FedoraRequestType.UPDATE_METADATA,
+                FedoraRequestType.UPDATE_BINARY_FILE_CONTENT,
+                FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB,
+                FedoraRequestType.UPDATE_BINARY_FILE_CONTENT_THUMB_LARGE,
+            ):
+                response = requests.put(url, headers=headers, data=data, auth=auth, verify=False)
+            elif request_type == FedoraRequestType.CREATE_BINARY_FILE:
+                response = requests.post(url, headers=headers, auth=auth, data=data, verify=False)
+            elif request_type in (
+                FedoraRequestType.DELETE_CONTAINER,
+                FedoraRequestType.DELETE_TOMBSTONE,
+                FedoraRequestType.DELETE_LINK_CONTAINER,
+                FedoraRequestType.DELETE_LINK_TOMBSTONE,
+                FedoraRequestType.DELETE_BINARY_FILE_COMPLETELY,
+                FedoraRequestType.CONNECT_DELETED_RECORD_3,
+                FedoraRequestType.CONNECT_DELETED_RECORD_4,
+                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_5,
+            ):
+                response = requests.delete(url, headers=headers, auth=auth)
+            elif request_type in (
+                FedoraRequestType.RECORD_DELETION_MOVE_MEMBERS,
+                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_2,
+                FedoraRequestType.DELETE_BINARY_FILE,
+                FedoraRequestType.CONNECT_DELETED_RECORD_1,
+                FedoraRequestType.CONNECT_DELETED_RECORD_2,
+                FedoraRequestType.CHANGE_IDENT_CONNECT_RECORDS_6,
+                FedoraRequestType.METADATA_UPDATE_RDF_DATA,
+                FedoraRequestType.FILE_CONTENT_UPDATE_RDF_DATA,
+                FedoraRequestType.THUMB_CONTENT_UPDATE_RDF_DATA,
+                FedoraRequestType.THUMB_LARGE_CONTENT_UPDATE_RDF_DATA,
+            ):
+                response = requests.patch(url, auth=auth, headers=headers, data=data)
+        except requests.exceptions.ConnectionError as exc:
+            logger.error(
+                "core_repository_connector._send_request.connection_error",
+                extra={"url": url, "request_type": request_type, "transaction": self.transaction_uid, "error": exc},
+            )
+            raise FedoraNoResponseError(url, str(exc), None, fedora_transaction=self.transaction)
         extra["status_code"] = response.status_code
 
         if request_type in (
@@ -2049,7 +2056,14 @@ class FedoraTransaction(BaseFedoraTransaction):
             f"{settings.FEDORA_PROTOCOL}://{settings.FEDORA_SERVER_HOSTNAME}:{settings.FEDORA_PORT_NUMBER}/rest/fcr:tx"
         )
         auth = HTTPBasicAuth(settings.FEDORA_USER, settings.FEDORA_USER_PASSWORD)
-        response = requests.post(url, auth=auth, verify=False)
+        try:
+            response = requests.post(url, auth=auth, verify=False)
+        except requests.exceptions.ConnectionError as exc:
+            logger.error(
+                "core_repository_connector.FedoraTransaction.__create_transaction.connection_error",
+                extra={"url": url, "error": exc},
+            )
+            raise FedoraNoResponseError(url, str(exc), None, fedora_transaction=None)
         if not str(response.status_code).startswith("2"):
             logger.error(
                 "core_repository_connector.FedoraTransaction.__create_transaction.failed",

--- a/webclient/fedora_management/decorators.py
+++ b/webclient/fedora_management/decorators.py
@@ -1,8 +1,11 @@
 import logging
 from functools import wraps
 
-from core.repository_connector import FedoraError
+from core.message_constants import CHYBA_SPOJENI_REPOZITAR
+from core.repository_connector import FedoraError, FedoraNoResponseError
+from django.contrib import messages
 from django.db import transaction
+from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 
@@ -32,6 +35,7 @@ def handle_fedora_error(view_func=None, additional_exceptions=tuple()):
         def _wrapped(*args, **kwargs):
             """
             Zavolá obalenou funkci a při výjimce FedoraError nastaví uzavření transakce na rollback a přesměruje uživatele.
+            Při výjimce FedoraNoResponseError (nedostupný repozitář) zobrazí uživateli chybovou zprávu.
 
             :param args: Poziční argumenty předané obalené funkci.
             :param kwargs: Klíčové argumenty předané obalené funkci.
@@ -42,8 +46,22 @@ def handle_fedora_error(view_func=None, additional_exceptions=tuple()):
             except (FedoraError,) + additional_exceptions as err:
                 logger.info("fedora_management.decorators.handle_fedora_error", extra={"error": err})
                 if err.fedora_transaction:
-                    err.fedora_transaction.rollback_transaction()
+                    try:
+                        err.fedora_transaction.rollback_transaction()
+                    except Exception as rollback_err:
+                        logger.warning(
+                            "fedora_management.decorators.handle_fedora_error.rollback_failed",
+                            extra={"error": err, "rollback_error": rollback_err},
+                        )
                 transaction.set_rollback(True)
+                if isinstance(err, FedoraNoResponseError):
+                    request = args[0]
+                    messages.add_message(request, messages.ERROR, CHYBA_SPOJENI_REPOZITAR)
+                    if request.META.get("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest":
+                        return JsonResponse({"error": "connection_failed"}, status=503)
+                    if err.ident_cely:
+                        return redirect(reverse("core:redirect_ident", kwargs={"ident_cely": err.ident_cely}))
+                    return redirect(reverse("core:home"))
                 if err.redirect or err.redirect_url:
                     if err.redirect_url:
                         return redirect(err.redirect_url)

--- a/webclient/projekt/views.py
+++ b/webclient/projekt/views.py
@@ -852,34 +852,48 @@ def schvalit(request, ident_cely):
         logger.debug("projekt.views.schvalit.post.start", extra={"ident_cely": ident_cely})
         old_ident = projekt.ident_cely
         fedora_transaction = projekt.create_transaction(request.user, PROJEKT_USPESNE_SCHVALEN)
-        if projekt.ident_cely[0] == "X":
-            try:
-                projekt.set_permanent_ident_cely()
-            except MaximalIdentNumberError:
-                logger.debug("projekt.views.schvalit.post.max_error", extra={"ident_cely": ident_cely})
-                fedora_transaction.error_message = MAXIMUM_IDENT_DOSAZEN
-                fedora_transaction.rollback_transaction()
-                return JsonResponse(
-                    {"redirect": reverse("projekt:detail", kwargs={"ident_cely": ident_cely})},
-                    status=403,
-                )
-            else:
-                logger.debug(
-                    "projekt.views.schvalit.perm_ident",
-                    extra={"ident_cely_old": old_ident, "ident_cely": projekt.ident_cely},
-                )
-        projekt.set_schvaleny(request.user, old_ident)
-        form = NeodeslatMailForm(request.POST)
-        if form.is_valid():
-            send_mail = form.cleaned_data["send_mail"]  # Získání hodnoty checkboxu
-            if send_mail:
-                if projekt.typ_projektu.pk == TYP_PROJEKTU_ZACHRANNY_ID:
-                    rep_bin_file = projekt.create_confirmation_document(fedora_transaction, user=request.user)
+        try:
+            if projekt.ident_cely[0] == "X":
+                try:
+                    projekt.set_permanent_ident_cely()
+                except MaximalIdentNumberError:
+                    logger.debug("projekt.views.schvalit.post.max_error", extra={"ident_cely": ident_cely})
+                    fedora_transaction.error_message = MAXIMUM_IDENT_DOSAZEN
+                    fedora_transaction.rollback_transaction()
+                    return JsonResponse(
+                        {"redirect": reverse("projekt:detail", kwargs={"ident_cely": ident_cely})},
+                        status=403,
+                    )
                 else:
-                    rep_bin_file = None
-                projekt.send_ep01(rep_bin_file)
-        projekt.close_active_transaction_when_finished = True
-        projekt.save()
+                    logger.debug(
+                        "projekt.views.schvalit.perm_ident",
+                        extra={"ident_cely_old": old_ident, "ident_cely": projekt.ident_cely},
+                    )
+            projekt.set_schvaleny(request.user, old_ident)
+            form = NeodeslatMailForm(request.POST)
+            if form.is_valid():
+                send_mail = form.cleaned_data["send_mail"]  # Získání hodnoty checkboxu
+                if send_mail:
+                    if projekt.typ_projektu.pk == TYP_PROJEKTU_ZACHRANNY_ID:
+                        rep_bin_file = projekt.create_confirmation_document(fedora_transaction, user=request.user)
+                    else:
+                        rep_bin_file = None
+                    projekt.send_ep01(rep_bin_file)
+            projekt.close_active_transaction_when_finished = True
+            projekt.save()
+        except Exception:
+            logger.exception(
+                "projekt.views.schvalit.post.error",
+                extra={"ident_cely": ident_cely, "transaction": fedora_transaction.uid},
+            )
+            try:
+                fedora_transaction.rollback_transaction()
+            except Exception:
+                logger.exception(
+                    "projekt.views.schvalit.post.rollback_error",
+                    extra={"ident_cely": ident_cely, "transaction": fedora_transaction.uid},
+                )
+            raise
         logger.debug(
             "projekt.views.schvalit.post.done",
             extra={"ident_cely_old": old_ident, "ident_cely": ident_cely, "transaction": fedora_transaction.uid},


### PR DESCRIPTION
#3823
**Příčina incidentu (2026-04-13 08:56)**
Při výpadku DNS překladu fedora.aiscr.cz uvnitř Docker kontejneru selhal HTTP request do Fedory s výjimkou socket.gaierror (→ requests.exceptions.ConnectionError). Tato výjimka nebyla v kódu ošetřena:

_send_request ji nepřeváděl na interní FedoraError — šíření jako syrová ConnectionError
handle_fedora_error zachytával pouze FedoraError, nikoliv ConnectionError → uživatel viděl HTTP 500
Otevřená Fedora transakce nebyla uzavřena ani rollbackována → způsobila řetěz HTTP 409 Conflict pro následující požadavky od jiných uživatelů

**Změny**
core/repository_connector.py

_send_request: všechny zápisové operace (POST/PUT/PATCH/DELETE) obaleny do try/except ConnectionError → výjimka se převede na FedoraNoResponseError. GET větve mají vlastní obsluhu a jsou nedotčeny.
FedoraTransaction.__create_transaction: stejný fix pro requests.post při zakládání transakce — pokud je repozitář nedostupný již v okamžiku create_transaction(), výjimka se také převede na FedoraNoResponseError.

fedora_management/decorators.py

rollback v handle_fedora_error obaleno do try/except — pokud spojení stále neběží, selhání rollbacku nezakryje původní výjimku
přidána obsluha FedoraNoResponseError: uživateli se zobrazí chybová zpráva (CHYBA_SPOJENI_REPOZITAR); AJAX požadavky obdrží JsonResponse(status=503) a prohlížeč stránku znovu načte; non-AJAX požadavky jsou přesměrovány na detail záznamu (nebo na home)

projekt/views.py — schvalit

Fedora operace v POST větvi obaleny do try/except Exception s loggingem transakce
rollback v bloku zachycení chyby obaleno do vlastního try/except — zajistí, že původní výjimka (např. FedoraNoResponseError) se znovu vyhodí (raise) a dojde do dekorátoru, i když rollback selže z důvodu nedostupnosti repozitáře
core/message_constants.py

přidána konstanta CHYBA_SPOJENI_REPOZITAR (klíč common.message.CHYBA_SPOJENI_REPOZITAR.text) — nutno doplnit překlad