### PR TITLE
Oprava testů

### DIFF
--- a/docs/source/04_django_aplikace/04_02_moduly/core/views.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/core/views.rst
@@ -818,12 +818,13 @@ Funkce
 
    :return: Vrací hodnotu podle větve zpracování, typicky: bool, hodnotu podle větve zpracování.
 
-.. py:function:: check_stav_changed(request, zaznam)
+.. py:function:: check_stav_changed(request, zaznam, prefix)
 
    Ověří, zda se stav záznamu mezitím změnil oproti hodnotě odeslané ve formuláři.
 
    :param request: Parametr ``request`` předává se do volání ``CheckStavNotChangedForm()``, ``add_message()``, pracuje se s atributy ``method``, ``POST``, ovlivňuje větvení podmínek.
    :param zaznam: Ukládaný záznam, jehož stav se porovnává.
+   :param prefix: Volitelný prefix formuláře použitý při renderování, nutný pro správné načtení ``old_stav`` z POST dat.
 
    :return: Vrací ``True`` nebo ``False`` podle vyhodnocení podmínek.
 

--- a/webclient/core/templates/core/transakce_table_modal.html
+++ b/webclient/core/templates/core/transakce_table_modal.html
@@ -122,7 +122,7 @@
     if (!tag.length) return;
 
     const syncRowsWithSelection = function () {
-        const selectedValues = tag.val() || [];
+        const selectedValues = [].concat(tag.val() || []);
         const selectedIds = new Set(selectedValues.map(String));
 
         $(cl + " table tbody tr[id^='modaldoc']").each(function () {

--- a/webclient/core/tests/test_selenium.py
+++ b/webclient/core/tests/test_selenium.py
@@ -39,6 +39,7 @@ from selenium.common.exceptions import (
     WebDriverException,
 )
 from selenium.webdriver.chrome.webdriver import WebDriver as ChromeDriver
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from uzivatel.models import User
@@ -826,9 +827,15 @@ class BaseSeleniumTestClass(LiveServerTestCase):
         attempts = 0
         while attempts < 10:
             try:
-                self.driver.find_element(by, value).click()
+                element = self.driver.find_element(by, value)
+                self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", element)
+                time.sleep(0.3)
+                try:
+                    element.click()
+                except (ElementClickInterceptedException, ElementNotInteractableException):
+                    self.driver.execute_script("arguments[0].click();", element)
                 return
-            except (StaleElementReferenceException, ElementClickInterceptedException, ElementNotInteractableException):
+            except StaleElementReferenceException:
                 attempts += 1
                 time.sleep(0.5)
 
@@ -881,7 +888,7 @@ class BaseSeleniumTestClass(LiveServerTestCase):
         :param position_x: Číselná hodnota ``position_x`` použitá při výpočtu nebo transformaci.
         :param position_y: Číselná hodnota ``position_y`` použitá při výpočtu nebo transformaci.
         """
-        action = webdriver.common.action_chains.ActionChains(self.driver)
+        action = ActionChains(self.driver)
         action.move_to_element_with_offset(el, position_x, position_y)
         action.click()
         action.perform()

--- a/webclient/core/tests/test_selenium.py
+++ b/webclient/core/tests/test_selenium.py
@@ -31,8 +31,6 @@ from PIL import Image, ImageChops
 from rdflib import XSD, Graph, Literal, URIRef
 from selenium import webdriver
 from selenium.common.exceptions import (
-    ElementClickInterceptedException,
-    ElementNotInteractableException,
     InvalidSessionIdException,
     NoSuchElementException,
     StaleElementReferenceException,
@@ -829,11 +827,7 @@ class BaseSeleniumTestClass(LiveServerTestCase):
             try:
                 element = self.driver.find_element(by, value)
                 self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", element)
-                time.sleep(0.3)
-                try:
-                    element.click()
-                except (ElementClickInterceptedException, ElementNotInteractableException):
-                    self.driver.execute_script("arguments[0].click();", element)
+                element.click()
                 return
             except StaleElementReferenceException:
                 attempts += 1

--- a/webclient/core/tests/test_selenium.py
+++ b/webclient/core/tests/test_selenium.py
@@ -31,6 +31,7 @@ from PIL import Image, ImageChops
 from rdflib import XSD, Graph, Literal, URIRef
 from selenium import webdriver
 from selenium.common.exceptions import (
+    ElementClickInterceptedException,
     InvalidSessionIdException,
     NoSuchElementException,
     StaleElementReferenceException,
@@ -823,7 +824,7 @@ class BaseSeleniumTestClass(LiveServerTestCase):
             raise Exception("ElementIsNotClickableError")
 
         attempts = 0
-        while attempts < 10:
+        while attempts < 15:
             try:
                 element = self.driver.find_element(by, value)
                 self.driver.execute_script(
@@ -831,9 +832,9 @@ class BaseSeleniumTestClass(LiveServerTestCase):
                 )
                 element.click()
                 return
-            except StaleElementReferenceException:
+            except (StaleElementReferenceException, ElementClickInterceptedException):
                 attempts += 1
-                time.sleep(0.5)
+                time.sleep(0.3)
 
         logger.warning("BaseSeleniumTestClass.ElementClick.failedAfterRetries", extra={"filed": by, "value": value})
         raise Exception("ElementClickError")

--- a/webclient/core/tests/test_selenium.py
+++ b/webclient/core/tests/test_selenium.py
@@ -826,7 +826,9 @@ class BaseSeleniumTestClass(LiveServerTestCase):
         while attempts < 10:
             try:
                 element = self.driver.find_element(by, value)
-                self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", element)
+                self.driver.execute_script(
+                    "arguments[0].scrollIntoView({block: 'center', behavior: 'instant'});", element
+                )
                 element.click()
                 return
             except StaleElementReferenceException:

--- a/webclient/core/views.py
+++ b/webclient/core/views.py
@@ -1207,18 +1207,19 @@ def get_projekt_soubor_name(projekt: Projekt, file_name):
     # Potřebné odstranit omezení `soubor_filepath_key`.
 
 
-def check_stav_changed(request, zaznam):
+def check_stav_changed(request, zaznam, prefix=None):
     """
     Ověří, zda se stav záznamu mezitím změnil oproti hodnotě odeslané ve formuláři.
 
     :param request: Parametr ``request`` předává se do volání ``CheckStavNotChangedForm()``, ``add_message()``, pracuje se s atributy ``method``, ``POST``, ovlivňuje větvení podmínek.
     :param zaznam: Ukládaný záznam, jehož stav se porovnává.
+    :param prefix: Volitelný prefix formuláře použitý při renderování, nutný pro správné načtení ``old_stav`` z POST dat.
 
         :return: Vrací ``True`` nebo ``False`` podle vyhodnocení podmínek.
     """
     logger.debug("core.views.check_stav_changed.start", extra={"pk": zaznam.pk})
     if request.method == "POST":
-        form_check = CheckStavNotChangedForm(data=request.POST, db_stav=zaznam.stav)
+        form_check = CheckStavNotChangedForm(data=request.POST, db_stav=zaznam.stav, prefix=prefix)
         if form_check.is_valid():
             pass
         else:

--- a/webclient/pas/tests/test_selenium.py
+++ b/webclient/pas/tests/test_selenium.py
@@ -296,15 +296,10 @@ class AkceSamostatneNalezy(BaseSeleniumTestClass):
         self.goToAddress("/pas/detail/C-202211308-N00213")
         self.ElementClick(By.CSS_SELECTOR, "#pas-potvrdit > .app-controls-button-text")
         self.wait(1)
-        self.ElementClick(By.CSS_SELECTOR, ".col-sm-3:nth-child(1) > #div_id_evidencni_cislo #id_evidencni_cislo")
-        self.driver.find_element(
-            By.CSS_SELECTOR, ".col-sm-3:nth-child(1) > #div_id_evidencni_cislo #id_evidencni_cislo"
-        ).send_keys("123")
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_predano .filter-option-inner-inner")
-        self.ElementClick(By.ID, "bs-select-1-0")
-
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_pristupnost .filter-option-inner-inner")
-        self.ElementClick(By.CSS_SELECTOR, "#bs-select-2-3 > .text")
+        self.ElementClick(By.ID, "id_potvrdit-evidencni_cislo")
+        self.driver.find_element(By.ID, "id_potvrdit-evidencni_cislo").send_keys("123")
+        self.select_nth_selectpicker_option("id_potvrdit-predano")
+        self.select_nth_selectpicker_option("id_potvrdit-pristupnost")
         with WaitForPageLoad(self.driver):
             self.ElementClick(By.ID, "submit-btn")
 
@@ -348,15 +343,10 @@ class AkceSamostatneNalezy(BaseSeleniumTestClass):
         self.goToAddress("/pas/detail/C-202211308-N00213")
         self.ElementClick(By.CSS_SELECTOR, "#pas-potvrdit > .app-controls-button-text")
         self.wait(1)
-        self.ElementClick(By.CSS_SELECTOR, ".col-sm-3:nth-child(1) > #div_id_evidencni_cislo #id_evidencni_cislo")
-        self.driver.find_element(
-            By.CSS_SELECTOR, ".col-sm-3:nth-child(1) > #div_id_evidencni_cislo #id_evidencni_cislo"
-        ).send_keys("123")
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_predano .filter-option-inner-inner")
-        # self.ElementClick(By.ID, "bs-select-1-0")
-
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_pristupnost .filter-option-inner-inner")
-        self.ElementClick(By.CSS_SELECTOR, "#bs-select-2-3 > .text")
+        self.ElementClick(By.ID, "id_potvrdit-evidencni_cislo")
+        self.driver.find_element(By.ID, "id_potvrdit-evidencni_cislo").send_keys("123")
+        # self.select_nth_selectpicker_option("id_potvrdit-predano")
+        self.select_nth_selectpicker_option("id_potvrdit-pristupnost")
         try:
             with WaitForPageLoad(self.driver, 5):
                 self.ElementClick(By.ID, "submit-btn")
@@ -402,14 +392,10 @@ class AkceSamostatneNalezy(BaseSeleniumTestClass):
 
         self.goToAddress("/pas/detail/C-202211308-N00213")
         self.ElementClick(By.CSS_SELECTOR, "#pas-potvrdit > .app-controls-button-text")
-        # self.ElementClick(By.CSS_SELECTOR, ".col-sm-3:nth-child(1) > #div_id_evidencni_cislo #id_evidencni_cislo")
-        # self.driver.find_element(By.CSS_SELECTOR, ".col-sm-3:nth-child(1) > #div_id_evidencni_cislo #id_evidencni_cislo").send_keys("123")
-        self.wait(1)
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_predano .filter-option-inner-inner")
-        self.ElementClick(By.ID, "bs-select-1-0")
-
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_pristupnost .filter-option-inner-inner")
-        self.ElementClick(By.CSS_SELECTOR, "#bs-select-2-3 > .text")
+        self.ElementClick(By.ID, "id_potvrdit-evidencni_cislo")
+        # self.driver.find_element(By.ID, "id_potvrdit-evidencni_cislo").send_keys("123")
+        self.select_nth_selectpicker_option("id_potvrdit-predano")
+        self.select_nth_selectpicker_option("id_potvrdit-pristupnost")
         try:
             with WaitForPageLoad(self.driver, 5):
                 self.ElementClick(By.ID, "submit-btn")
@@ -626,9 +612,9 @@ class AkceSamostatneNalezy(BaseSeleniumTestClass):
         # Úprava uložení
         time = self.getTime()
         self.ElementClick(By.ID, "pas-edit-ulozeni")
-        self.ElementSendKeys(By.CSS_SELECTOR, ".modal-body #id_evidencni_cislo", "1")
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_pristupnost .btn")
-        self.ElementClick(By.CSS_SELECTOR, "#bs-select-2-1 > .text")
+        self.ElementClick(By.ID, "id_edit-ulozeni-evidencni_cislo")
+        self.driver.find_element(By.ID, "id_edit-ulozeni-evidencni_cislo").send_keys("1")
+        self.select_nth_selectpicker_option("id_edit-ulozeni-pristupnost")
         with WaitForPageLoad(self.driver):
             self.ElementClick(By.ID, "submit-btn")
         self.check_fedora_change(time, "pas/tests/resources/test_147/update_ulozeni")

--- a/webclient/pas/views.py
+++ b/webclient/pas/views.py
@@ -490,13 +490,13 @@ def edit_ulozeni(request, ident_cely):
     """
     sn = get_object_or_404(SamostatnyNalez, ident_cely=ident_cely)
     predano_required = True if sn.stav == SN_POTVRZENY else False
-    if check_stav_changed(request, sn):
+    if check_stav_changed(request, sn, prefix="edit-ulozeni"):
         return JsonResponse(
             {"redirect": reverse("pas:detail", kwargs={"ident_cely": ident_cely})},
             status=403,
         )
     if request.method == "POST":
-        form = PotvrditNalezForm(request.POST, instance=sn, predano_required=predano_required)
+        form = PotvrditNalezForm(request.POST, instance=sn, predano_required=predano_required, prefix="edit-ulozeni")
         if form.is_valid():
             logger.debug("pas.views.edit_ulozeni.form_valid")
             sn: SamostatnyNalez = form.save(commit=False)
@@ -521,6 +521,7 @@ def edit_ulozeni(request, ident_cely):
             predano_required=predano_required,
             initial={"old_stav": sn.stav},
             predano_hidden=True,
+            prefix="edit-ulozeni",
         )
     context = {
         "object": sn,
@@ -672,7 +673,7 @@ def potvrdit(request, ident_cely):
             {"redirect": reverse("pas:detail", kwargs={"ident_cely": ident_cely})},
             status=403,
         )
-    if check_stav_changed(request, sn):
+    if check_stav_changed(request, sn, prefix="potvrdit"):
         return JsonResponse(
             {"redirect": reverse("pas:detail", kwargs={"ident_cely": ident_cely})},
             status=403,
@@ -687,7 +688,7 @@ def potvrdit(request, ident_cely):
             status=403,
         )
     if request.method == "POST":
-        form = PotvrditNalezForm(request.POST, instance=sn, predano_required=True)
+        form = PotvrditNalezForm(request.POST, instance=sn, predano_required=True, prefix="potvrdit")
         if form.is_valid():
             form_obj: SamostatnyNalez = form.save(commit=False)
             form_obj.create_transaction(request.user, SAMOSTATNY_NALEZ_POTVRZEN)
@@ -699,7 +700,7 @@ def potvrdit(request, ident_cely):
         else:
             logger.info("pas.views.potvrdit.form_invalid", extra={"error": form.errors})
     else:
-        form = PotvrditNalezForm(instance=sn, initial={"old_stav": sn.stav}, predano_hidden=True)
+        form = PotvrditNalezForm(instance=sn, initial={"old_stav": sn.stav}, predano_hidden=True, prefix="potvrdit")
     context = {
         "object": sn,
         "form": form,

--- a/webclient/projekt/tests/test_selenium.py
+++ b/webclient/projekt/tests/test_selenium.py
@@ -439,9 +439,9 @@ class ProjektSeleniumTest(BaseSeleniumTestClass):
         # zmena pristupnosti PAS
         time = self.getTime()
         self.ElementClick(By.ID, "pas-edit-ulozeni")
-        self.ElementSendKeys(By.CSS_SELECTOR, ".modal-body #id_evidencni_cislo", "1")
-        self.ElementClick(By.CSS_SELECTOR, "#div_id_pristupnost .btn")
-        self.ElementClick(By.CSS_SELECTOR, "#bs-select-2-1 > .text")
+        self.ElementClick(By.ID, "id_edit-ulozeni-evidencni_cislo")
+        self.driver.find_element(By.ID, "id_edit-ulozeni-evidencni_cislo").send_keys("1")
+        self.select_nth_selectpicker_option("id_edit-ulozeni-pristupnost")
         with WaitForPageLoad(self.driver):
             self.ElementClick(By.ID, "submit-btn")
         self.check_fedora_change(time, "projekt/tests/resources/test_146/zmena_pristupnosti")

--- a/webclient/static/js/dz_import_pian.js
+++ b/webclient/static/js/dz_import_pian.js
@@ -65,7 +65,9 @@ window.onload = function () {
         init: function () {
             this.on("success", function (file, response) {
                 file.id = response.id
-                file.previewElement.lastChild.style.display = null
+                if (file.previewElement && file.previewElement.lastElementChild) {
+                    file.previewElement.lastElementChild.style.display = null;
+                }
                 show_upload_successful_message(file, UploadResultsEnum.success);
                 $("#my-awesome-dropzone").attr('style','display:none !important');
                 $("#import-helptext").attr('style','display:none !important');
@@ -74,7 +76,9 @@ window.onload = function () {
                 this.removeFile(file);
             });
             this.on("sending", function (file) {
-                file.previewElement.lastChild.style.display = "none"
+                if (file.previewElement && file.previewElement.lastElementChild) {
+                    file.previewElement.lastElementChild.style.display = "none";
+                }
             });
 
         },


### PR DESCRIPTION
**pas/views.py + core/views.py — oprava formulářových prefixů**

- Funkce check_stav_changed() dostala volitelný parametr prefix, který se předává do CheckStavNotChangedForm. Bez něj nešlo správně načíst old_stav z POST dat při použití prefixovaných formulářů.

- View funkce edit_ulozeni a potvrdit nyní předávají prefix "edit-ulozeni" resp. "potvrdit" do formuláře PotvrditNalezForm a do check_stav_changed, aby nedošlo ke konfliktu ID na html stránce.

**Selenium testy (pas/, projekt/, core/)**

- Opraveny selektory elementů — staré CSS selektory (.col-sm-3:nth-child(1) > #div_id_evidencni_cislo #id_evidencni_cislo, #div_id_predano .filter-option-inner-inner, atd.) nahrazeny přímými ID selektory reflektujícími nové prefixované názvy polí (id_potvrdit-evidencni_cislo, id_edit-ulozeni-evidencni_cislo).

- Klikání na selectpicker přes select_nth_selectpicker_option() místo křehkých #bs-select-X-Y selektorů.

- ElementClick v core/test_selenium.py vylepšen: před kliknutím scrolluje element do středu viewportu.

- Import ActionChains přesunut na top-level místo webdriver.common.action_chains.ActionChains.

**core/templates/core/transakce_table_modal.html**
Opraveno: tag.val() může vracet null nebo string místo pole — [].concat(tag.val() || []) zajistí vždy pole.

**static/js/dz_import_pian.js**
Přidána null-guard kontrola file.previewElement && file.previewElement.lastElementChild před přístupem ke stylu při Dropzone upload events.