### PR TITLE
Úpravy po testování importu #3194

### DIFF
--- a/docs/source/04_django_aplikace/04_02_moduly/pas/api.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pas/api.rst
@@ -678,6 +678,8 @@ Třídy
       - ``geom_system=5514`` — zdrojem je ``geom_sjtsk_wkt``; ``geom`` se vypočítá
         konverzí do WGS-84, element ``geom_wkt`` se ignoruje.
 
+      ``stav`` — musí být jedna z povolených hodnot (1, 2, 3); určuje cílový stav záznamu po importu.
+
       Následující elementy jsou v XML povoleny, ale při importu se ignorují:
 
       - ``igsn`` — přiděluje se automaticky po archivaci záznamu.
@@ -687,7 +689,6 @@ Třídy
       - ``geom_sjtsk_gml`` (v ``chranene_udaje``) — geometrie se přebírá z ``geom_sjtsk_wkt``.
       - ``geom_sjtsk_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=4326``.
       - ``geom_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=5514``.
-      - ``stav`` — musí být jedna z povolených hodnot (1, 2, 3); určuje cílový stav záznamu po importu.
       - ``historie`` — generuje se automaticky systémem.
       - ``soubor`` — soubory se nahrávají samostatným endpointem.
 
@@ -722,6 +723,7 @@ Třídy
       Teprve pokud záznam neexistuje, vytvoří se nová osoba z textu ve formátu
       ``"Příjmení, Jméno"``. Nová osoba se zde pouze připraví, ale uloží se až
       v transakci společně s ``SamostatnyNalez``.
+      Vytvoření nové osoby tímto importním tokem nevyžaduje samostatné oprávnění.
 
       :param elem: Element ``amcr:samostatny_nalez``.
       :param user: Uživatel provádějící import.
@@ -739,8 +741,11 @@ Třídy
 
       Importuje nový záznam samostatného nálezu z XML souboru.
 
-      Přijímá soubor v parametru ``file`` (multipart/form-data). XML musí odpovídat
-      schématu AMČR 2.2 (https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd).
+      Přijímá soubor v parametru ``file`` (multipart/form-data). XML musí projít validací
+      proti XSD schématu AMČR deklarovanému v dokumentu (verze 2.2 na URL
+      ``https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd`` nebo novější). Volitelné nastavení administrace
+      ``allowed_schema_versions`` může omezit povolené číslo verze schématu v namespace
+      dokumentu (viz ``PasApiPermissionMixin.get_allowed_schema_versions``).
       Dokument musí obsahovat právě jeden element ``amcr:samostatny_nalez``.
 
       :param request: HTTP požadavek obsahující XML soubor v poli ``file``.

--- a/docs/source/04_django_aplikace/04_02_moduly/pas/api.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pas/api.rst
@@ -226,6 +226,28 @@ Třídy
       :raises ValidationError: Pokud struktura nebo hodnoty neodpovídají očekávání.
       :return: ``True`` pokud je nastavení validní.
 
+   .. py:method:: validate_allowed_schema_versions()
+
+      Ověří strukturu a obsah nastavení ``allowed_schema_versions``.
+
+      Očekávaný formát je neprázdný seznam čísel (``float`` nebo ``int``),
+      například ``[2.2]`` nebo ``[2.2, 2.3]``. Záporné nebo nulové hodnoty nejsou povoleny.
+
+      :param raw_versions: Naparsovaná JSON hodnota nastavení ``allowed_schema_versions``.
+
+      :raises ValidationError: Pokud hodnota není neprázdný seznam kladných čísel.
+      :return: ``True`` pokud je nastavení validní.
+
+   .. py:method:: get_allowed_schema_versions()
+
+      Vrátí seznam povolených verzí AMČR XSD schématu z cache nebo ``CustomAdminSettings``.
+
+      Pokud nastavení ``allowed_schema_versions`` neexistuje, vrátí ``None`` (povoleny jsou
+      všechny verze, které projdou ostatními kontrolami). Pokud nastavení existuje, vrátí
+      seznam hodnot jako ``float``.
+
+      :return: Seznam povolených verzí nebo ``None``, pokud nastavení není nakonfigurováno.
+
    .. py:method:: get_client_ip()
 
       Vrátí IP adresu klienta z požadavku.
@@ -560,7 +582,11 @@ Třídy
 
       Ověří, že XML deklaruje podporovanou verzi AMČR schématu.
 
+      Pokud je předán parametr ``allowed_versions``, zkontroluje navíc, zda verze schématu
+      v dokumentu patří mezi povolené verze nakonfigurované v nastavení ``allowed_schema_versions``.
+
       :param doc: Naparsovaný XML dokument.
+      :param allowed_versions: Seznam povolených verzí schématu nebo ``None`` (bez omezení).
 
       :return: Chybová zpráva nebo ``None``, pokud deklarace odpovídá podporované verzi.
 
@@ -628,42 +654,79 @@ Třídy
 
       :return: Hodnota atributu ``id`` nebo None, pokud element nebo atribut neexistuje.
 
+   .. py:method:: _parse_point_wkt()
+
+      Ověří, že text XML elementu obsahuje platné WKT geometrie typu ``Point``.
+
+      :param elem: XML element obsahující WKT text.
+      :param field_name: Název pole pro chybovou zprávu (``"geom_wkt"`` nebo ``"geom_sjtsk_wkt"``).
+
+      :return: WKT řetězec geometrie.
+
+      :raises ImportValidationException: Pokud je WKT syntakticky neplatné, prázdné nebo není typu ``Point``.
+
    .. py:method:: _parse_nalez_element()
 
       Převede element ``amcr:samostatny_nalez`` na slovník pro deserializaci.
 
       Elementy typu ``refType`` a ``vocabType`` se mapují pomocí atributu ``id``,
-      který nese ``ident_cely`` odkazovaného záznamu. Geometrie jsou předány
-      jako WKT řetězce z elementů ``geom_wkt`` a ``geom_sjtsk_wkt``.
+      který nese ``ident_cely`` odkazovaného záznamu. Geometrie se určují vždy
+      z jednoho zdrojového elementu podle ``geom_system``:
+
+      - ``geom_system=4326`` — zdrojem je ``geom_wkt``; ``geom_sjtsk`` se vypočítá
+        konverzí do S-JTSK, element ``geom_sjtsk_wkt`` se ignoruje.
+      - ``geom_system=5514`` — zdrojem je ``geom_sjtsk_wkt``; ``geom`` se vypočítá
+        konverzí do WGS-84, element ``geom_wkt`` se ignoruje.
+
+      Následující elementy jsou v XML povoleny, ale při importu se ignorují:
+
+      - ``igsn`` — přiděluje se automaticky po archivaci záznamu.
+      - ``okres`` — stanoví se automaticky podle souřadnic.
+      - ``katastr`` (v ``chranene_udaje``) — stanoví se automaticky podle souřadnic.
+      - ``geom_gml`` (v ``chranene_udaje``) — geometrie se přebírá z ``geom_wkt``.
+      - ``geom_sjtsk_gml`` (v ``chranene_udaje``) — geometrie se přebírá z ``geom_sjtsk_wkt``.
+      - ``geom_sjtsk_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=4326``.
+      - ``geom_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=5514``.
+      - ``stav`` — musí být jedna z povolených hodnot (1, 2, 3); určuje cílový stav záznamu po importu.
+      - ``historie`` — generuje se automaticky systémem.
+      - ``soubor`` — soubory se nahrávají samostatným endpointem.
 
       :param elem: Element ``amcr:samostatny_nalez`` z importovaného XML dokumentu.
       :param user: Uživatel provádějící import.
 
       :return: Dvojice ``(data, nova_osoba)`` připravená pro import.
 
+   .. py:method:: _parse_geom_fields()
+
+      Načte a převede geometrie podle ``geom_system``.
+
+      Při ``geom_system="4326"`` se jako zdroj použije ``geom_wkt`` a výsledek se
+      konvertuje do S-JTSK (5514). Element ``geom_sjtsk_wkt`` se ignoruje.
+      Při ``geom_system="5514"`` se jako zdroj použije ``geom_sjtsk_wkt`` a výsledek
+      se konvertuje do WGS-84 (4326). Element ``geom_wkt`` se ignoruje.
+
+      :param chranene: Element ``amcr:chranene_udaje``.
+      :param geom_system: Hodnota elementu ``geom_system`` z importovaného dokumentu.
+
+      :return: Dvojice ``(geom_wgs84, geom_sjtsk)`` nebo ``None`` pro každou hodnotu,
+          která nebyla nalezena nebo nebyla poskytnuta.
+
+      :raises ImportValidationException: Pokud konverze souřadnic selže.
+
    .. py:method:: _parse_nalezce()
 
       Zpracuje element ``nalezce`` a vrátí ``ident_cely`` osoby pro import.
 
-      Pokud má element atribut ``id=":tba"``, vytvoří se nová osoba z textu
-      ve formátu ``"Příjmení, Jméno"``. Nová osoba se zde pouze připraví,
-      ale uloží se až v transakci společně s ``SamostatnyNalez``.
+      Pokud má element atribut ``id=":tba"``, nejprve se prohledá databáze podle
+      ``prijmeni`` a ``jmeno``. Pokud osoba existuje, použije se její ``ident_cely``.
+      Teprve pokud záznam neexistuje, vytvoří se nová osoba z textu ve formátu
+      ``"Příjmení, Jméno"``. Nová osoba se zde pouze připraví, ale uloží se až
+      v transakci společně s ``SamostatnyNalez``.
 
       :param elem: Element ``amcr:samostatny_nalez``.
       :param user: Uživatel provádějící import.
 
       :return: Dvojice ``(ident_cely_osoby, nova_osoba)``.
-
-   .. py:method:: _build_schema_validation_doc()
-
-      Vytvoří kopii dokumentu upravenou pro validaci proti XSD schématu.
-
-      XSD vyžaduje element ``stav``. Pokud v dokumentu chybí, doplní se do kopie
-      pro účely validace; originální dokument zůstává nezměněn.
-
-      :param doc: Původní XML dokument.
-
-      :return: Kopie XML dokumentu určená pro schema validaci.
 
 
 .. py:class:: SamostatnyNalezXmlImportView
@@ -698,18 +761,14 @@ Třídy
 
    .. py:method:: _create_import_history_records()
 
-      Vytvoří historii pro importovaný záznam samostatného nálezu.
+      Vytvoří záznamy historie pro importovaný samostatný nález.
+
+      Vytvoří pouze záznamy odpovídající přechodům až do cílového stavu záznamu:
+      stav 1 → ZAPSANI_SN, stav 2 → ZAPSANI_SN + ODESLANI_SN,
+      stav 3 → ZAPSANI_SN + ODESLANI_SN + POTVRZENI_SN.
 
       :param instance: Vytvořený záznam samostatného nálezu.
       :param user: Uživatel, který provedl import.
-
-   .. py:method:: _validate_disallowed_elements()
-
-      Ověří, že importovaný element neobsahuje nepovolené podřízené elementy.
-
-      :param elem: Importovaný element ``amcr:samostatny_nalez``.
-
-      :raises ImportValidationException: Pokud je nalezen nepovolený element.
 
 
 .. py:class:: SamostatnyNalezEvidencniCisloPatchView
@@ -824,6 +883,32 @@ Třídy
 
 Funkce
 ------
+
+.. py:function:: _xsd_redis_key(url)
+
+   Sestaví klíč pro Redis cache pro XSD schéma na zadané URL.
+
+   Pro URL AMČR schématu (obsahující ``/schema/amcr/<verze>/``) je klíč ve tvaru
+   ``xsd_schema:amcr:<verze>:<url>``, jinak ``xsd_schema:<url>``.
+
+   :param url: URL XSD souboru.
+
+   :return: Řetězec klíče pro Redis cache.
+
+.. py:function:: _fetch_xsd_bytes(url)
+
+   Načte bajty XSD schématu ze zadaného URL.
+
+   Pořadí vyhledávání: in-process slovník → Redis → síť. Výsledek se uloží
+   do obou úložišť, takže každá URL je v rámci procesu načtena nejvýše jednou.
+
+   :param url: URL XSD souboru ke stažení.
+
+   :return: Bajty XSD schématu.
+
+   :raises urllib.error.URLError: Pokud se nepodaří navázat spojení s URL.
+   :raises TimeoutError: Pokud vyprší časový limit požadavku.
+   :raises ValueError: Pokud server vrátí prázdné tělo odpovědi.
 
 .. py:function:: _is_valid_ip_rule_value(value)
 

--- a/docs/source/05_integrace/pas_api.rst
+++ b/docs/source/05_integrace/pas_api.rst
@@ -186,8 +186,7 @@ Některé elementy systém stanoví nebo generuje automaticky a v importu se ign
   Při ``geom_system=4326`` se katastr odvozuje z ``geom_wkt``, při ``geom_system=5514`` se ``geom_sjtsk_wkt``
   nejprve transformuje do WGS-84 a katastr se odvozuje z výsledku.
   Pokud souřadnice nespadají do žádného katastru (např. bod mimo území ČR), import selže s HTTP 422.
-- ``amcr:stav`` — povinný element vyžadovaný XSD schématem; hodnota v XML se ignoruje a systém nastaví
-  stav automaticky (záznam vstupuje do systému ve stavu **Potvrzený**).
+- ``amcr:stav`` — musí být jedna z povolených hodnot (1, 2, 3); určuje cílový stav záznamu po importu.
 - ``amcr:evidencni_cislo`` — lze uvést v importu; systém hodnotu přijme a uloží.
 - ``amcr:historie``, ``amcr:soubor`` — pouze pro export.
 

--- a/docs/source/05_integrace/pas_api.rst
+++ b/docs/source/05_integrace/pas_api.rst
@@ -172,7 +172,7 @@ třech je jako poznámka uvedeno, že záznam pochází z importu z externího z
      - ``xs:string``
      - Použije se, pokud ``amcr:geom_system`` je ``5514``; atribut ``EPSG`` obsahuje kód souřadnicového systému.
 
-U elementů s atributem ``xml:lang`` se očekává hodnota ``cs``; v praxi však import hodnotu ignoruje.
+U elementů s atributem ``xml:lang`` se očekává hodnota ``cs``.
 
 Elementy odkazující na heslář (``okolnosti``, ``obdobi``, ``druh_nalezu``, ``specifikace``,
 ``pristupnost``) a na organizaci (``predano_organizace``) se uvádějí celé včetně textové hodnoty, protože
@@ -180,14 +180,14 @@ XML musí projít validací schématu. Pro import se využívá atribut ``id``; 
 hodnota ``id`` patří do správného typu hesláře (např. nelze do pole ``obdobi`` uvést kód hesláře
 pro druh nálezu). Textový obsah elementu se při importu ignoruje.
 
-Elementy ``amcr:stav``, ``amcr:historie`` a ``amcr:soubor`` jsou v importu zakázány nebo
-se stanoví automaticky:
+Některé elementy systém stanoví nebo generuje automaticky a v importu se ignorují nebo nejsou povoleny:
 
 - ``amcr:okres``, ``amcr:katastr`` — určí systém automaticky podle souřadnic; v importu nejsou povoleny.
   Při ``geom_system=4326`` se katastr odvozuje z ``geom_wkt``, při ``geom_system=5514`` se ``geom_sjtsk_wkt``
   nejprve transformuje do WGS-84 a katastr se odvozuje z výsledku.
   Pokud souřadnice nespadají do žádného katastru (např. bod mimo území ČR), import selže s HTTP 422.
-- ``amcr:stav`` — přiděluje systém; v importu není povolen.
+- ``amcr:stav`` — povinný element vyžadovaný XSD schématem; hodnota v XML se ignoruje a systém nastaví
+  stav automaticky (záznam vstupuje do systému ve stavu **Potvrzený**).
 - ``amcr:evidencni_cislo`` — lze uvést v importu; systém hodnotu přijme a uloží.
 - ``amcr:historie``, ``amcr:soubor`` — pouze pro export.
 
@@ -216,7 +216,7 @@ i pokud jsou v dokumentu přítomny.
         <amcr:poznamka>xs:string</amcr:poznamka>
         <amcr:nalezce id="xs:string">xs:string, xs:string</amcr:nalezce>
         <amcr:datum_nalezu>xs:date</amcr:datum_nalezu>
-        <!-- <amcr:stav>xs:integer</amcr:stav> -->
+        <amcr:stav>xs:integer</amcr:stav> <!-- povinné XSD; hodnota se ignoruje, systém nastaví stav automaticky -->
         <amcr:predano>xs:boolean</amcr:predano>
         <amcr:predano_organizace id="xs:string" xml:lang="cs">xs:string</amcr:predano_organizace>
         <amcr:geom_system>xs:integer</amcr:geom_system>

--- a/docs/source/05_integrace/pas_api.rst
+++ b/docs/source/05_integrace/pas_api.rst
@@ -215,7 +215,7 @@ i pokud jsou v dokumentu přítomny.
         <amcr:poznamka>xs:string</amcr:poznamka>
         <amcr:nalezce id="xs:string">xs:string, xs:string</amcr:nalezce>
         <amcr:datum_nalezu>xs:date</amcr:datum_nalezu>
-        <amcr:stav>xs:integer</amcr:stav> <!-- povinné XSD; hodnota se ignoruje, systém nastaví stav automaticky -->
+        <amcr:stav>xs:integer</amcr:stav>
         <amcr:predano>xs:boolean</amcr:predano>
         <amcr:predano_organizace id="xs:string" xml:lang="cs">xs:string</amcr:predano_organizace>
         <amcr:geom_system>xs:integer</amcr:geom_system>

--- a/webclient/core/admin.py
+++ b/webclient/core/admin.py
@@ -373,6 +373,7 @@ class PermissionAdmin(admin.ModelAdmin):
         )
 
 
+@admin.register(ApiRequestLog)
 class ApiRequestLogAdmin(admin.ModelAdmin):
     """Třída admin panelu pro zobrazení logů API požadavků."""
 
@@ -434,9 +435,6 @@ class ApiRequestLogAdmin(admin.ModelAdmin):
         :return: Vždy ``False``.
         """
         return False
-
-
-admin.site.register(ApiRequestLog, ApiRequestLogAdmin)
 
 
 @admin.register(PermissionsSkip)

--- a/webclient/pas/api.py
+++ b/webclient/pas/api.py
@@ -27,23 +27,28 @@ from core.constants import (
     ODESLANI_SN,
     POTVRZENI_SN,
     SN_ARCHIVOVANY,
+    SN_ODESLANY,
     SN_POTVRZENY,
+    SN_ZAPSANY,
     ZAPSANI_SN,
 )
+from core.coordTransform import transform_geom_to_sjtsk, transform_geom_to_wgs84
 from core.ident_cely import get_sn_ident
 from core.models import AntivirusCheckResult, ApiRequestLog, Permissions, Soubor, check_permissions
 from core.repository_connector import FedoraError, FedoraRepositoryConnector, FedoraTransaction, FedoraTransactionStatus
 from core.setting_models import CustomAdminSettings
 from core.utils import get_cadastre_from_point
 from core.views import get_finds_soubor_name
+from django.contrib.gis.geos import GEOSException, GEOSGeometry
+from django.contrib.gis.geos import Point as GEOSPoint
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.db import DatabaseError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.http import HttpResponse, JsonResponse
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_lazy as _l
+from django.utils.translation import gettext_lazy
 from heslar.hesla import (
     HESLAR_NALEZOVE_OKOLNOSTI,
     HESLAR_OBDOBI,
@@ -82,6 +87,8 @@ _RECORD_LOCK_TTL = 300  # sekund — zámek záznamu vyprší po 5 minutách
 _RECORD_LOCK_DEFAULT_RETRY_DELAY = 0.5  # sekund — výchozí čekací interval mezi pokusy
 _RECORD_LOCK_DEFAULT_MAX_RETRIES = 10  # výchozí maximální počet pokusů o získání zámku
 _CACHE_KEY_RECORD_LOCK_PARAMS = "pas_api_record_lock_params"
+_CACHE_KEY_ALLOWED_SCHEMA_VERSIONS = "pas_api_allowed_schema_versions"
+_NOT_CONFIGURED = "__pas_api_not_configured__"  # sentinel: nastavení neexistuje (odliší se od None = cache miss)
 
 _PAS_API_GROUP = "pas_api"
 _ACCESS_RULES_ID = "access_rules"
@@ -90,14 +97,17 @@ _ACCESS_MODE_ID = "access_mode"
 # codeql[py/clear-text-logging-sensitive-data]
 _TRUSTED_PROXIES_ID = "trusted_proxies"
 _RECORD_LOCK_PARAMS_ID = "record_lock_params"
+_ALLOWED_SCHEMA_VERSIONS_ID = "allowed_schema_versions"
 _AMCR_SCHEMA_LOCK = threading.Lock()
 _AMCR_SCHEMA_FETCH_TIMEOUT = 10
 _AMCR_SCHEMA_CACHE_TTL = 3600  # sekund — schéma se znovu načte po 60 minutách
-_ALLOWED_XML_XSD_URLS = (
-    "http://www.w3.org/2001/xml.xsd",
-    "https://www.w3.org/2001/xml.xsd",
-    "http://www.w3.org/2001/03/xml.xsd",
-    "https://www.w3.org/2001/03/xml.xsd",
+_ALLOWED_XML_XSD_URLS = frozenset(
+    (
+        "http://www.w3.org/2001/xml.xsd",
+        "https://www.w3.org/2001/xml.xsd",
+        "http://www.w3.org/2001/03/xml.xsd",
+        "https://www.w3.org/2001/03/xml.xsd",
+    )
 )
 _ALLOWED_SCHEMA_URL_PATTERNS = (
     re.compile(r"^https?://www\.w3\.org/2001/XMLSchema-instance(?:[?#].*)?$"),
@@ -105,6 +115,63 @@ _ALLOWED_SCHEMA_URL_PATTERNS = (
     re.compile(r"^https://api\.aiscr\.cz/schema/amcr/\d+\.\d+/.*$"),
     re.compile(r"^http://www\.opengis\.net/gml/.*$"),
 )
+
+
+_XSD_BYTES_CACHE: dict[str, bytes] = {}
+_XSD_BYTES_CACHE_LOCK = threading.Lock()
+
+
+def _xsd_redis_key(url: str) -> str:
+    """
+    Sestaví klíč pro Redis cache pro XSD schéma na zadané URL.
+
+    Pro URL AMČR schématu (obsahující ``/schema/amcr/<verze>/``) je klíč ve tvaru
+    ``xsd_schema:amcr:<verze>:<url>``, jinak ``xsd_schema:<url>``.
+
+    :param url: URL XSD souboru.
+
+    :return: Řetězec klíče pro Redis cache.
+    """
+    m = re.search(r"/schema/amcr/(\d+\.\d+)/", url)
+    if m:
+        return f"xsd_schema:amcr:{m.group(1)}:{url}"
+    return f"xsd_schema:{url}"
+
+
+def _fetch_xsd_bytes(url: str) -> bytes:
+    """
+    Načte bajty XSD schématu ze zadaného URL.
+
+    Pořadí vyhledávání: in-process slovník → Redis → síť. Výsledek se uloží
+    do obou úložišť, takže každá URL je v rámci procesu načtena nejvýše jednou.
+
+    :param url: URL XSD souboru ke stažení.
+
+    :return: Bajty XSD schématu.
+
+    :raises urllib.error.URLError: Pokud se nepodaří navázat spojení s URL.
+    :raises TimeoutError: Pokud vyprší časový limit požadavku.
+    :raises ValueError: Pokud server vrátí prázdné tělo odpovědi.
+    """
+    if url in _XSD_BYTES_CACHE:
+        return _XSD_BYTES_CACHE[url]
+    with _XSD_BYTES_CACHE_LOCK:
+        if url in _XSD_BYTES_CACHE:
+            return _XSD_BYTES_CACHE[url]
+        cache_key = _xsd_redis_key(url)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            _XSD_BYTES_CACHE[url] = cached
+            return cached
+        response = urllib.request.urlopen(url, timeout=_AMCR_SCHEMA_FETCH_TIMEOUT)  # noqa: S310
+        with response:
+            content = response.read()
+        if not content:
+            logger.warning("pas.api._fetch_xsd_bytes.empty_response", extra={"url": url})
+            raise ValueError(f"pas.api._fetch_xsd_bytes.empty_response: {url}")
+        cache.set(cache_key, content, timeout=_AMCR_SCHEMA_CACHE_TTL)
+        _XSD_BYTES_CACHE[url] = content
+        return content
 
 
 def _is_valid_ip_rule_value(value: str) -> bool:
@@ -159,7 +226,14 @@ ACCESS_MODE_OPEN = "open"
 ACCESS_MODE_WHITELIST_ONLY = "whitelist_only"
 ACCESS_MODE_CLOSED = "closed"
 _ACCESS_MODES = {ACCESS_MODE_OPEN, ACCESS_MODE_WHITELIST_ONLY, ACCESS_MODE_CLOSED}
-_PAS_API_ITEM_IDS = {_ACCESS_RULES_ID, _RATE_LIMITS_ID, _ACCESS_MODE_ID, _TRUSTED_PROXIES_ID, _RECORD_LOCK_PARAMS_ID}
+_PAS_API_ITEM_IDS = {
+    _ACCESS_RULES_ID,
+    _RATE_LIMITS_ID,
+    _ACCESS_MODE_ID,
+    _TRUSTED_PROXIES_ID,
+    _RECORD_LOCK_PARAMS_ID,
+    _ALLOWED_SCHEMA_VERSIONS_ID,
+}
 
 # codeql[py/clear-text-logging-sensitive-data]
 _DEFAULT_TRUSTED_PROXIES = []
@@ -305,7 +379,7 @@ class PasApiPermissionMixin:
         except CustomAdminSettings.DoesNotExist:
             return []
         except (json.JSONDecodeError, TypeError):
-            logger.error("pas.api._load_json_setting.invalid_json")
+            logger.warning("pas.api._load_json_setting.invalid_json")
             if raise_validation_error:
                 # item_id in the validation message is likewise intentional:
                 # it identifies which PAS admin setting is malformed and helps
@@ -439,6 +513,8 @@ class PasApiPermissionMixin:
             cls.validate_trusted_proxies(raw_value)
         elif instance.item_id == _RECORD_LOCK_PARAMS_ID:
             cls.validate_record_lock_params(raw_value)
+        elif instance.item_id == _ALLOWED_SCHEMA_VERSIONS_ID:
+            cls.validate_allowed_schema_versions(raw_value)
         return True
 
     @classmethod
@@ -693,6 +769,55 @@ class PasApiPermissionMixin:
                 )
         return True
 
+    @staticmethod
+    def validate_allowed_schema_versions(raw_versions) -> bool:
+        """
+        Ověří strukturu a obsah nastavení ``allowed_schema_versions``.
+
+        Očekávaný formát je neprázdný seznam čísel (``float`` nebo ``int``),
+        například ``[2.2]`` nebo ``[2.2, 2.3]``. Záporné nebo nulové hodnoty nejsou povoleny.
+
+        :param raw_versions: Naparsovaná JSON hodnota nastavení ``allowed_schema_versions``.
+
+        :raises ValidationError: Pokud hodnota není neprázdný seznam kladných čísel.
+        :return: ``True`` pokud je nastavení validní.
+        """
+        if not isinstance(raw_versions, list) or not raw_versions:
+            raise ValidationError(
+                {"value": _("pas.api.PasApiPermissionMixin.validate_allowed_schema_versions.not_a_nonempty_list")}
+            )
+        for item in raw_versions:
+            if isinstance(item, bool) or not isinstance(item, (int, float)) or item <= 0:
+                raise ValidationError(
+                    {"value": _("pas.api.PasApiPermissionMixin.validate_allowed_schema_versions.invalid_version")}
+                )
+        return True
+
+    @classmethod
+    def get_allowed_schema_versions(cls) -> list[float] | None:
+        """
+        Vrátí seznam povolených verzí AMČR XSD schématu z cache nebo ``CustomAdminSettings``.
+
+        Pokud nastavení ``allowed_schema_versions`` neexistuje, vrátí ``None`` (povoleny jsou
+        všechny verze, které projdou ostatními kontrolami). Pokud nastavení existuje, vrátí
+        seznam hodnot jako ``float``.
+
+        :return: Seznam povolených verzí nebo ``None``, pokud nastavení není nakonfigurováno.
+        """
+        versions = cache.get(_CACHE_KEY_ALLOWED_SCHEMA_VERSIONS)
+        if versions is None:
+            raw = cls.load_json_setting(_ALLOWED_SCHEMA_VERSIONS_ID, raise_validation_error=False)
+            if not raw:
+                cache.set(_CACHE_KEY_ALLOWED_SCHEMA_VERSIONS, _NOT_CONFIGURED, _CACHE_TTL)
+                return None
+            cls.validate_allowed_schema_versions(raw)
+            versions = [float(v) for v in raw]
+            cache.set(_CACHE_KEY_ALLOWED_SCHEMA_VERSIONS, versions, _CACHE_TTL)
+            return versions
+        if versions == _NOT_CONFIGURED:
+            return None
+        return versions
+
     @classmethod
     def get_client_ip(cls, request) -> str:
         """
@@ -785,6 +910,7 @@ def _invalidate_api_cache(sender, instance=None, **kwargs):
         cache.delete(_CACHE_KEY_ACCESS_MODE)
         cache.delete(_CACHE_KEY_TRUSTED_PROXIES)
         cache.delete(_CACHE_KEY_RECORD_LOCK_PARAMS)
+        cache.delete(_CACHE_KEY_ALLOWED_SCHEMA_VERSIONS)
 
 
 class IpBlacklistPermission(PasApiPermissionMixin, BasePermission):
@@ -1046,7 +1172,7 @@ class ApiImportThrottle(PasApiPermissionMixin, BaseThrottle):
         """
         parsed = _parse_rate(rate)
         if parsed is None:
-            logger.error("pas.api.ApiImportThrottle.invalid_rate", extra={"rate": rate})
+            logger.warning("pas.api.ApiImportThrottle.invalid_rate", extra={"rate": rate})
             return True
         max_requests, window = parsed
         now = time.time()
@@ -1473,7 +1599,7 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
     _XML_NS = "http://www.w3.org/XML/1998/namespace"
     _XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
     _amcr_schema_cache: dict[str, tuple[etree.XMLSchema, float]] = {}  # url -> (schema, inserted_at)
-    XML_IMPORT_INITIAL_STAV: int = SN_POTVRZENY
+    _VALID_IMPORT_STAVS: tuple[int, ...] = (SN_ZAPSANY, SN_ODESLANY, SN_POTVRZENY)
 
     def _validation_status(self, errors: list[ImportValidationIssue]) -> int:
         """
@@ -1490,11 +1616,17 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
         return status.HTTP_422_UNPROCESSABLE_ENTITY
 
     @classmethod
-    def _validate_declared_schema_version(cls, doc: etree._ElementTree) -> str | None:
+    def _validate_declared_schema_version(
+        cls, doc: etree._ElementTree, allowed_versions: list[float] | None = None
+    ) -> str | None:
         """
         Ověří, že XML deklaruje podporovanou verzi AMČR schématu.
 
+        Pokud je předán parametr ``allowed_versions``, zkontroluje navíc, zda verze schématu
+        v dokumentu patří mezi povolené verze nakonfigurované v nastavení ``allowed_schema_versions``.
+
         :param doc: Naparsovaný XML dokument.
+        :param allowed_versions: Seznam povolených verzí schématu nebo ``None`` (bez omezení).
 
         :return: Chybová zpráva nebo ``None``, pokud deklarace odpovídá podporované verzi.
         """
@@ -1517,6 +1649,18 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
             return _(
                 "pas.api.SamostatnyNalezXmlImportView._validate_declared_schema_version.unsupported_schema_location"
             )
+
+        if allowed_versions is not None:
+            m = re.search(r"/schema/amcr/(\d+\.\d+)/", amcr_namespace)
+            if m is None:
+                return _(
+                    "pas.api.SamostatnyNalezXmlImportView._validate_declared_schema_version.version_not_extractable"
+                )
+            version = float(m.group(1))
+            if version not in allowed_versions:
+                return _(
+                    "pas.api.SamostatnyNalezXmlImportView._validate_declared_schema_version.version_not_allowed"
+                ) % {"version": version}
 
         return None
 
@@ -1555,22 +1699,24 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
 
                 def resolve(self, url, id, context):
                     """
-                    Přeloží URL na lokální cestu pro xml.xsd.
+                    Načte URL XSD schématu ze sítě nebo Redis cache a vrátí obsah resolveru.
 
                     :param url: URL požadovaného zdroje.
                     :param id: Identifikátor kontextu parseru.
                     :param context: Kontext resolveru.
 
-                    :return: Vrací lokální soubor pro xml.xsd, jinak None.
+                    :return: Vrací obsah XSD schématu pro povolená URL, jinak None.
                     """
-                    allowed_urls = _ALLOWED_XML_XSD_URLS
-                    if url in allowed_urls:
-                        return self.resolve_filename("xml_generator/definitions/xml.xsd", context)
-                    if any(pattern.match(url) for pattern in _ALLOWED_SCHEMA_URL_PATTERNS):
+                    if url in _ALLOWED_XML_XSD_URLS or any(
+                        pattern.match(url) for pattern in _ALLOWED_SCHEMA_URL_PATTERNS
+                    ):
+                        # W3C xml.xsd and all other allowed schema URLs are fetched from the network
+                        # (cached in Redis after first fetch). If the remote is unavailable, the import
+                        # endpoint returns 422 — this is intentional: we do not bundle local copies.
                         try:
-                            response = urllib.request.urlopen(url, timeout=_AMCR_SCHEMA_FETCH_TIMEOUT)  # noqa: S310
-                        except (urllib.error.URLError, TimeoutError) as exc:
-                            logger.error("Nepodařilo se načíst XSD schéma z URL %s: %s", url, exc)
+                            content = _fetch_xsd_bytes(url)
+                        except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+                            logger.warning("Nepodařilo se načíst XSD schéma z URL %s: %s", url, exc)
                             self.blocked_exception = ImportValidationException(
                                 ImportValidationIssue(
                                     line=None,
@@ -1584,7 +1730,7 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
                             )
                             self.blocked_exception.__cause__ = exc
                             return None
-                        return self.resolve_file(response, context, base_url=url)
+                        return self.resolve_string(content, context, base_url=url)
                     # Disallowed URL — store the exception for re-raising after XMLSchema()
                     # because lxml swallows Python exceptions raised inside resolver callbacks.
                     self.blocked_exception = ImportValidationException(
@@ -1602,9 +1748,9 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
             resolver = _LocalResolver()
             parser.resolvers.add(resolver)
             try:
-                response = urllib.request.urlopen(schema_url, timeout=_AMCR_SCHEMA_FETCH_TIMEOUT)  # noqa: S310
-            except (urllib.error.URLError, TimeoutError) as exc:
-                logger.error("Nepodařilo se načíst XSD schéma z URL %s: %s", schema_url, exc)
+                xsd_bytes = _fetch_xsd_bytes(schema_url)
+            except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+                logger.warning("Nepodařilo se načíst XSD schéma z URL %s: %s", schema_url, exc)
                 raise ImportValidationException(
                     ImportValidationIssue(
                         line=None,
@@ -1614,8 +1760,7 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
                         error_type=ImportErrorType.INVALID_DATA,
                     )
                 ) from exc
-            with response:
-                schema_doc = etree.parse(response, parser)
+            schema_doc = etree.ElementTree(etree.fromstring(xsd_bytes, parser))
             schema = etree.XMLSchema(schema_doc)
             if resolver.blocked_exception is not None:
                 raise resolver.blocked_exception
@@ -1728,13 +1873,75 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
         return child.get("id") or None
 
     @classmethod
+    def _parse_point_wkt(cls, elem: etree._Element, field_name: str) -> str:
+        """
+        Ověří, že text XML elementu obsahuje platné WKT geometrie typu ``Point``.
+
+        :param elem: XML element obsahující WKT text.
+        :param field_name: Název pole pro chybovou zprávu (``"geom_wkt"`` nebo ``"geom_sjtsk_wkt"``).
+
+        :return: WKT řetězec geometrie.
+
+        :raises ImportValidationException: Pokud je WKT syntakticky neplatné, prázdné nebo není typu ``Point``.
+        """
+        wkt = (elem.text or "").strip()
+        if not wkt:
+            raise ImportValidationException(
+                ImportValidationIssue(
+                    line=elem.sourceline,
+                    column=None,
+                    message=f"{field_name}: " + _("pas.api.SamostatnyNalezXmlBaseView._parse_point_wkt.empty_wkt"),
+                    error_type=ImportErrorType.INVALID_DATA,
+                )
+            )
+        try:
+            geom = GEOSGeometry(wkt)
+        except (GEOSException, ValueError):
+            raise ImportValidationException(
+                ImportValidationIssue(
+                    line=elem.sourceline,
+                    column=None,
+                    message=f"{field_name}: " + _("pas.api.SamostatnyNalezXmlBaseView._parse_point_wkt.invalid_wkt"),
+                    error_type=ImportErrorType.INVALID_DATA,
+                )
+            ) from None
+        if not isinstance(geom, GEOSPoint):
+            raise ImportValidationException(
+                ImportValidationIssue(
+                    line=elem.sourceline,
+                    column=None,
+                    message=f"{field_name}: " + _("pas.api.SamostatnyNalezXmlBaseView._parse_point_wkt.not_a_point"),
+                    error_type=ImportErrorType.INVALID_DATA,
+                )
+            )
+        return wkt
+
+    @classmethod
     def _parse_nalez_element(cls, elem: etree._Element, user) -> tuple[dict, Osoba | None]:
         """
         Převede element ``amcr:samostatny_nalez`` na slovník pro deserializaci.
 
         Elementy typu ``refType`` a ``vocabType`` se mapují pomocí atributu ``id``,
-        který nese ``ident_cely`` odkazovaného záznamu. Geometrie jsou předány
-        jako WKT řetězce z elementů ``geom_wkt`` a ``geom_sjtsk_wkt``.
+        který nese ``ident_cely`` odkazovaného záznamu. Geometrie se určují vždy
+        z jednoho zdrojového elementu podle ``geom_system``:
+
+        - ``geom_system=4326`` — zdrojem je ``geom_wkt``; ``geom_sjtsk`` se vypočítá
+          konverzí do S-JTSK, element ``geom_sjtsk_wkt`` se ignoruje.
+        - ``geom_system=5514`` — zdrojem je ``geom_sjtsk_wkt``; ``geom`` se vypočítá
+          konverzí do WGS-84, element ``geom_wkt`` se ignoruje.
+
+        Následující elementy jsou v XML povoleny, ale při importu se ignorují:
+
+        - ``igsn`` — přiděluje se automaticky po archivaci záznamu.
+        - ``okres`` — stanoví se automaticky podle souřadnic.
+        - ``katastr`` (v ``chranene_udaje``) — stanoví se automaticky podle souřadnic.
+        - ``geom_gml`` (v ``chranene_udaje``) — geometrie se přebírá z ``geom_wkt``.
+        - ``geom_sjtsk_gml`` (v ``chranene_udaje``) — geometrie se přebírá z ``geom_sjtsk_wkt``.
+        - ``geom_sjtsk_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=4326``.
+        - ``geom_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=5514``.
+        - ``stav`` — musí být jedna z povolených hodnot (1, 2, 3); určuje cílový stav záznamu po importu.
+        - ``historie`` — generuje se automaticky systémem.
+        - ``soubor`` — soubory se nahrávají samostatným endpointem.
 
         :param elem: Element ``amcr:samostatny_nalez`` z importovaného XML dokumentu.
         :param user: Uživatel provádějící import.
@@ -1756,11 +1963,39 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
                 )
             )
 
+        raw_ident_cely = cls._text(elem, "ident_cely")
+        if raw_ident_cely is not None and raw_ident_cely != ":tba":
+            ident_cely_elem = elem.find(cls._ns("ident_cely"))
+            raise ImportValidationException(
+                ImportValidationIssue(
+                    line=ident_cely_elem.sourceline if ident_cely_elem is not None else elem.sourceline,
+                    column=None,
+                    message="ident_cely: "
+                    + _("pas.api.SamostatnyNalezXmlImportView._parse_nalez_element.ident_cely_must_be_tba"),
+                    error_type=ImportErrorType.INVALID_DATA,
+                )
+            )
+
+        raw_stav = cls._text(elem, "stav")
+        try:
+            stav = int(raw_stav) if raw_stav is not None else None
+        except (ValueError, TypeError):
+            stav = None
+        if stav not in cls._VALID_IMPORT_STAVS:
+            stav_elem = elem.find(cls._ns("stav"))
+            raise ImportValidationException(
+                ImportValidationIssue(
+                    line=stav_elem.sourceline if stav_elem is not None else elem.sourceline,
+                    column=None,
+                    message="stav: " + _("pas.api.SamostatnyNalezXmlBaseView._parse_nalez_element.unsupported_stav"),
+                    error_type=ImportErrorType.INVALID_DATA,
+                )
+            )
+
         data = {
-            "ident_cely": None if cls._text(elem, "ident_cely") == ":tba" else cls._text(elem, "ident_cely"),
+            "ident_cely": None,
             "projekt": projekt_ident,
             "evidencni_cislo": cls._text(elem, "evidencni_cislo"),
-            "igsn": cls._text(elem, "igsn"),
             "hloubka": cls._text(elem, "hloubka"),
             "okolnosti": cls._id_attr(elem, "okolnosti"),
             "obdobi": cls._id_attr(elem, "obdobi"),
@@ -1771,32 +2006,123 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
             "poznamka": cls._text(elem, "poznamka"),
             "nalezce": nalezce_ident,
             "datum_nalezu": cls._text(elem, "datum_nalezu"),
-            "stav": cls.XML_IMPORT_INITIAL_STAV,
+            "stav": stav,
             "predano": cls._parse_bool(cls._text(elem, "predano")),
             "predano_organizace": cls._id_attr(elem, "predano_organizace"),
             "geom_system": cls._text(elem, "geom_system"),
             "pristupnost": cls._id_attr(elem, "pristupnost"),
         }
 
+        geom_system = data.get("geom_system")
+        if geom_system is not None and geom_system not in ("4326", "5514"):
+            geom_system_elem = elem.find(cls._ns("geom_system"))
+            raise ImportValidationException(
+                ImportValidationIssue(
+                    line=geom_system_elem.sourceline if geom_system_elem is not None else elem.sourceline,
+                    column=None,
+                    message="geom_system: "
+                    + _("pas.api.SamostatnyNalezXmlBaseView._parse_nalez_element.unsupported_geom_system"),
+                    error_type=ImportErrorType.INVALID_DATA,
+                )
+            )
+
         if chranene is not None:
+            if geom_system not in ("4326", "5514"):
+                geom_system_elem = elem.find(cls._ns("geom_system"))
+                raise ImportValidationException(
+                    ImportValidationIssue(
+                        line=geom_system_elem.sourceline if geom_system_elem is not None else elem.sourceline,
+                        column=None,
+                        message="geom_system: "
+                        + _("pas.api.SamostatnyNalezXmlBaseView._parse_nalez_element.unsupported_geom_system"),
+                        error_type=ImportErrorType.INVALID_DATA,
+                    )
+                )
             data["lokalizace"] = cls._text(chranene, "lokalizace")
-            geom_wkt_elem = chranene.find(cls._ns("geom_wkt"))
-            if geom_wkt_elem is not None and geom_wkt_elem.text:
-                data["geom"] = geom_wkt_elem.text.strip()
-            geom_sjtsk_elem = chranene.find(cls._ns("geom_sjtsk_wkt"))
-            if geom_sjtsk_elem is not None and geom_sjtsk_elem.text:
-                data["geom_sjtsk"] = geom_sjtsk_elem.text.strip()
+            geom, geom_sjtsk = cls._parse_geom_fields(chranene, geom_system)
+            if geom is not None:
+                data["geom"] = geom
+            if geom_sjtsk is not None:
+                data["geom_sjtsk"] = geom_sjtsk
 
         return {k: v for k, v in data.items() if v is not None}, nova_osoba
+
+    @classmethod
+    def _parse_geom_fields(cls, chranene: etree._Element, geom_system: str | None) -> tuple[str | None, str | None]:
+        """
+        Načte a převede geometrie podle ``geom_system``.
+
+        Při ``geom_system="4326"`` se jako zdroj použije ``geom_wkt`` a výsledek se
+        konvertuje do S-JTSK (5514). Element ``geom_sjtsk_wkt`` se ignoruje.
+        Při ``geom_system="5514"`` se jako zdroj použije ``geom_sjtsk_wkt`` a výsledek
+        se konvertuje do WGS-84 (4326). Element ``geom_wkt`` se ignoruje.
+
+        :param chranene: Element ``amcr:chranene_udaje``.
+        :param geom_system: Hodnota elementu ``geom_system`` z importovaného dokumentu.
+
+        :return: Dvojice ``(geom_wgs84, geom_sjtsk)`` nebo ``None`` pro každou hodnotu,
+            která nebyla nalezena nebo nebyla poskytnuta.
+
+        :raises ImportValidationException: Pokud konverze souřadnic selže.
+        """
+        if geom_system == "4326":
+            wkt_elem = chranene.find(cls._ns("geom_wkt"))
+            if wkt_elem is None or not wkt_elem.text:
+                return None, None
+            wkt = cls._parse_point_wkt(wkt_elem, "geom_wkt")
+            try:
+                converted, result_status = transform_geom_to_sjtsk(wkt)
+                ok = result_status == "OK"
+            except Exception as exc:
+                logger.warning("pas.api._parse_geom_fields.sjtsk_conversion_failed", extra={"exc": str(exc)})
+                ok = False
+            if not ok:
+                raise ImportValidationException(
+                    ImportValidationIssue(
+                        line=wkt_elem.sourceline,
+                        column=None,
+                        message="geom_wkt: "
+                        + _("pas.api.SamostatnyNalezXmlBaseView._parse_geom_fields.conversion_error"),
+                        error_type=ImportErrorType.INVALID_DATA,
+                    )
+                )
+            return wkt, converted
+
+        if geom_system == "5514":
+            sjtsk_elem = chranene.find(cls._ns("geom_sjtsk_wkt"))
+            if sjtsk_elem is None or not sjtsk_elem.text:
+                return None, None
+            wkt_sjtsk = cls._parse_point_wkt(sjtsk_elem, "geom_sjtsk_wkt")
+            try:
+                converted, result_status = transform_geom_to_wgs84(wkt_sjtsk)
+                ok = result_status == "OK"
+            except Exception as exc:
+                logger.warning("pas.api._parse_geom_fields.wgs84_conversion_failed", extra={"exc": str(exc)})
+                ok = False
+            if not ok:
+                raise ImportValidationException(
+                    ImportValidationIssue(
+                        line=sjtsk_elem.sourceline,
+                        column=None,
+                        message="geom_sjtsk_wkt: "
+                        + _("pas.api.SamostatnyNalezXmlBaseView._parse_geom_fields.conversion_error"),
+                        error_type=ImportErrorType.INVALID_DATA,
+                    )
+                )
+            return converted, wkt_sjtsk
+
+        return None, None
 
     @classmethod
     def _parse_nalezce(cls, elem: etree._Element, user) -> tuple[str | None, Osoba | None]:
         """
         Zpracuje element ``nalezce`` a vrátí ``ident_cely`` osoby pro import.
 
-        Pokud má element atribut ``id=":tba"``, vytvoří se nová osoba z textu
-        ve formátu ``"Příjmení, Jméno"``. Nová osoba se zde pouze připraví,
-        ale uloží se až v transakci společně s ``SamostatnyNalez``.
+        Pokud má element atribut ``id=":tba"``, nejprve se prohledá databáze podle
+        ``prijmeni`` a ``jmeno``. Pokud osoba existuje, použije se její ``ident_cely``.
+        Teprve pokud záznam neexistuje, vytvoří se nová osoba z textu ve formátu
+        ``"Příjmení, Jméno"``. Nová osoba se zde pouze připraví, ale uloží se až
+        v transakci společně s ``SamostatnyNalez``.
 
         :param elem: Element ``amcr:samostatny_nalez``.
         :param user: Uživatel provádějící import.
@@ -1859,70 +2185,27 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
         if len(casti) != 2 or not casti[0] or not casti[1]:
             raise ImportValidationException(get_nalezce_format_error(nalezce_text, casti))
 
-        if not check_permissions(Permissions.actionChoices.model_edit, user):
-            raise ImportValidationException(
-                ImportValidationIssue(
-                    line=nalezce_elem.sourceline if nalezce_elem is not None else elem.sourceline,
-                    column=None,
-                    message="nalezce: "
-                    + _("pas.api.SamostatnyNalezXmlImportView._parse_nalezce.missing_edit_osoba_permission"),
-                    error_type=ImportErrorType.PERMISSION_ERROR,
-                )
-            )
-
         prijmeni, jmeno = casti
         jmeno = " ".join(jmeno.split())
+
+        existing = Osoba.objects.filter(prijmeni=prijmeni, jmeno=jmeno).first()
+        if existing is not None:
+            return existing.ident_cely, None
+
         osoba = Osoba(
             prijmeni=prijmeni,
             jmeno=jmeno,
             vypis=build_osoba_vypis(prijmeni, jmeno),
             vypis_cely=f"{prijmeni}, {jmeno}",
         )
+        osoba.suppress_signal = True
         return None, osoba
-
-    @classmethod
-    def _build_schema_validation_doc(cls, doc: etree._ElementTree) -> etree._ElementTree:
-        """
-        Vytvoří kopii dokumentu upravenou pro validaci proti XSD schématu.
-
-        XSD vyžaduje element ``stav``. Pokud v dokumentu chybí, doplní se do kopie
-        pro účely validace; originální dokument zůstává nezměněn.
-
-        :param doc: Původní XML dokument.
-
-        :return: Kopie XML dokumentu určená pro schema validaci.
-        """
-        parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
-        validation_doc = etree.ElementTree(etree.fromstring(etree.tostring(doc.getroot()), parser=parser))
-        for elem in validation_doc.findall(f".//{cls._ns('samostatny_nalez')}"):
-            if elem.find(cls._ns("stav")) is not None:
-                continue
-
-            stav_elem = etree.Element(cls._ns("stav"))
-            stav_elem.text = str(cls.XML_IMPORT_INITIAL_STAV)
-            insert_before_tags = (
-                "predano",
-                "predano_organizace",
-                "geom_system",
-                "pristupnost",
-                "chranene_udaje",
-                "historie",
-                "soubor",
-            )
-            insert_index = len(elem)
-            for index, child in enumerate(elem):
-                if _strip_namespace(child.tag) in insert_before_tags:
-                    insert_index = index
-                    break
-            elem.insert(insert_index, stav_elem)
-
-        return validation_doc
 
 
 class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
     """Pohled pro import záznamu samostatného nálezu z XML souboru přes POST požadavek."""
 
-    _IMPORT_HISTORY_NOTE = _l("pas.api.SamostatnyNalezXmlImportView.import_history_note")
+    _IMPORT_HISTORY_NOTE = gettext_lazy("pas.api.SamostatnyNalezXmlImportView.import_history_note")
 
     def post(self, request, format=None):
         """
@@ -1984,7 +2267,7 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        version_error = self._validate_declared_schema_version(doc)
+        version_error = self._validate_declared_schema_version(doc, allowed_versions=self.get_allowed_schema_versions())
         if version_error:
             return self._fail(log_entry, {"detail": version_error}, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
@@ -1997,8 +2280,7 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
                 self._validation_status(exc.import_errors),
             )
 
-        validation_doc = self._build_schema_validation_doc(doc)
-        if not schema.validate(validation_doc):
+        if not schema.validate(doc):
             errors = [
                 ImportValidationIssue(
                     line=e.line,
@@ -2052,7 +2334,6 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
         elem = nalez_elements[0]
         notes = self._get_ignored_lang_notes(elem)
         try:
-            self._validate_disallowed_elements(elem)
             data, nova_osoba = self._parse_nalez_element(elem, request.user)
         except ImportValidationException as exc:
             return self._fail(
@@ -2092,20 +2373,6 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
                 if not serializer.is_valid():
                     raise ImportValidationException.from_serializer_errors(serializer.errors, line=elem.sourceline)
 
-                if (
-                    serializer.validated_data.get("ident_cely")
-                    and SamostatnyNalez.objects.filter(ident_cely=serializer.validated_data["ident_cely"]).exists()
-                ):
-                    raise ImportValidationException(
-                        ImportValidationIssue(
-                            line=elem.sourceline,
-                            column=None,
-                            message="ident_cely: "
-                            + _("pas.api.SamostatnyNalezXmlImportView.post.ident_cely_already_exists"),
-                            error_type=ImportErrorType.INVALID_DATA,
-                        )
-                    )
-
                 instance = SamostatnyNalez(**serializer.validated_data)
                 if not instance.ident_cely:
                     instance.ident_cely = get_sn_ident(instance.projekt)
@@ -2118,6 +2385,7 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
                             error_type=ImportErrorType.INVALID_DATA,
                         )
                     )
+
                 geom_wgs84 = instance.geom
                 if geom_wgs84 is None and instance.geom_sjtsk is not None:
                     # Clone so that the stored geom_sjtsk field is never mutated; WGS-84 is
@@ -2144,13 +2412,27 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
                 # stays open after the DB commit, allowing us to verify the Fedora write below.
                 instance.save()
         except ImportValidationException as exc:
-            logger.error("pas.api.SamostatnyNalezXmlImportView.post.import_validation_error", extra={"error": exc})
+            logger.warning("pas.api.SamostatnyNalezXmlImportView.post.import_validation_error", extra={"error": exc})
             if fedora_transaction.status == FedoraTransactionStatus.ACTIVE:
                 fedora_transaction.rollback_transaction()
             return self._fail(
                 log_entry,
                 {"validation_errors": [e.to_dict() for e in exc.import_errors]},
                 self._validation_status(exc.import_errors),
+            )
+        except IntegrityError as err:
+            logger.warning("pas.api.SamostatnyNalezXmlImportView.post.integrity_error", extra={"error": err})
+            if fedora_transaction.status == FedoraTransactionStatus.ACTIVE:
+                fedora_transaction.rollback_transaction()
+            constraint = getattr(getattr(err.__cause__, "diag", None), "constraint_name", None)
+            if constraint == "osoba_jmeno_prijmeni_key":
+                detail = _("pas.api.SamostatnyNalezXmlImportView.post.nalezce_already_exists")
+            else:
+                detail = _("pas.api.SamostatnyNalezXmlImportView.post.integrity_error")
+            return self._fail(
+                log_entry,
+                {"detail": detail},
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
         except FedoraError as err:
             logger.error("pas.api.SamostatnyNalezXmlImportView.post.fedora_error", extra={"error": err})
@@ -2227,53 +2509,32 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
     @classmethod
     def _create_import_history_records(cls, instance: SamostatnyNalez, user) -> None:
         """
-        Vytvoří historii pro importovaný záznam samostatného nálezu.
+        Vytvoří záznamy historie pro importovaný samostatný nález.
+
+        Vytvoří pouze záznamy odpovídající přechodům až do cílového stavu záznamu:
+        stav 1 → ZAPSANI_SN, stav 2 → ZAPSANI_SN + ODESLANI_SN,
+        stav 3 → ZAPSANI_SN + ODESLANI_SN + POTVRZENI_SN.
 
         :param instance: Vytvořený záznam samostatného nálezu.
         :param user: Uživatel, který provedl import.
         """
+        _all_transitions = [
+            (SN_ZAPSANY, ZAPSANI_SN),
+            (SN_ODESLANY, ODESLANI_SN),
+            (SN_POTVRZENY, POTVRZENI_SN),
+        ]
         Historie.objects.bulk_create(
             [
                 Historie(
-                    typ_zmeny=ZAPSANI_SN,
+                    typ_zmeny=typ_zmeny,
                     uzivatel=user,
                     vazba=instance.historie,
                     poznamka=cls._IMPORT_HISTORY_NOTE,
-                ),
-                Historie(
-                    typ_zmeny=ODESLANI_SN,
-                    uzivatel=user,
-                    vazba=instance.historie,
-                    poznamka=cls._IMPORT_HISTORY_NOTE,
-                ),
-                Historie(
-                    typ_zmeny=POTVRZENI_SN,
-                    uzivatel=user,
-                    vazba=instance.historie,
-                    poznamka=cls._IMPORT_HISTORY_NOTE,
-                ),
+                )
+                for stav_threshold, typ_zmeny in _all_transitions
+                if instance.stav >= stav_threshold
             ]
         )
-
-    @classmethod
-    def _validate_disallowed_elements(cls, elem: etree._Element) -> None:
-        """
-        Ověří, že importovaný element neobsahuje nepovolené podřízené elementy.
-
-        :param elem: Importovaný element ``amcr:samostatny_nalez``.
-
-        :raises ImportValidationException: Pokud je nalezen nepovolený element.
-        """
-        stav_elem = elem.find(cls._ns("stav"))
-        if stav_elem is not None:
-            raise ImportValidationException(
-                ImportValidationIssue(
-                    line=stav_elem.sourceline,
-                    column=None,
-                    message="stav: " + _("pas.api.SamostatnyNalezXmlImportView.post.stav_element_not_allowed"),
-                    error_type=ImportErrorType.INVALID_DATA,
-                )
-            )
 
 
 class SamostatnyNalezEvidencniCisloPatchView(PasApiBaseView):

--- a/webclient/pas/api.py
+++ b/webclient/pas/api.py
@@ -2124,6 +2124,7 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
         Teprve pokud záznam neexistuje, vytvoří se nová osoba z textu ve formátu
         ``"Příjmení, Jméno"``. Nová osoba se zde pouze připraví, ale uloží se až
         v transakci společně s ``SamostatnyNalez``.
+        Vytvoření nové osoby tímto importním tokem nevyžaduje samostatné oprávnění.
 
         :param elem: Element ``amcr:samostatny_nalez``.
         :param user: Uživatel provádějící import.
@@ -2212,8 +2213,11 @@ class SamostatnyNalezXmlImportView(SamostatnyNalezXmlBaseView):
         """
         Importuje nový záznam samostatného nálezu z XML souboru.
 
-        Přijímá soubor v parametru ``file`` (multipart/form-data). XML musí odpovídat
-        schématu AMČR 2.2 (https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd).
+        Přijímá soubor v parametru ``file`` (multipart/form-data). XML musí projít validací
+        proti XSD schématu AMČR deklarovanému v dokumentu (verze 2.2 na URL
+        ``https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd`` nebo novější). Volitelné nastavení administrace
+        ``allowed_schema_versions`` může omezit povolené číslo verze schématu v namespace
+        dokumentu (viz ``PasApiPermissionMixin.get_allowed_schema_versions``).
         Dokument musí obsahovat právě jeden element ``amcr:samostatny_nalez``.
 
         :param request: HTTP požadavek obsahující XML soubor v poli ``file``.

--- a/webclient/pas/api.py
+++ b/webclient/pas/api.py
@@ -1930,6 +1930,8 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
         - ``geom_system=5514`` — zdrojem je ``geom_sjtsk_wkt``; ``geom`` se vypočítá
           konverzí do WGS-84, element ``geom_wkt`` se ignoruje.
 
+        ``stav`` — musí být jedna z povolených hodnot (1, 2, 3); určuje cílový stav záznamu po importu.
+
         Následující elementy jsou v XML povoleny, ale při importu se ignorují:
 
         - ``igsn`` — přiděluje se automaticky po archivaci záznamu.
@@ -1939,7 +1941,6 @@ class SamostatnyNalezXmlBaseView(PasApiBaseView):
         - ``geom_sjtsk_gml`` (v ``chranene_udaje``) — geometrie se přebírá z ``geom_sjtsk_wkt``.
         - ``geom_sjtsk_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=4326``.
         - ``geom_wkt`` (v ``chranene_udaje``) — ignoruje se, pokud ``geom_system=5514``.
-        - ``stav`` — musí být jedna z povolených hodnot (1, 2, 3); určuje cílový stav záznamu po importu.
         - ``historie`` — generuje se automaticky systémem.
         - ``soubor`` — soubory se nahrávají samostatným endpointem.
 

--- a/webclient/pas/tests/data/minimal_nalez.xml
+++ b/webclient/pas/tests/data/minimal_nalez.xml
@@ -7,6 +7,7 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
+    <amcr:stav>{STAV}</amcr:stav>
     <amcr:geom_system>{GEOM_SYSTEM}</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/minimal_nalez_no_geom.xml
+++ b/webclient/pas/tests/data/minimal_nalez_no_geom.xml
@@ -7,6 +7,7 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/minimal_nalez_no_stav.xml
+++ b/webclient/pas/tests/data/minimal_nalez_no_stav.xml
@@ -7,16 +7,9 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
-    <amcr:hloubka>42</amcr:hloubka>
-    <amcr:presna_datace>raný středověk</amcr:presna_datace>
-    <amcr:pocet>3</amcr:pocet>
-    <amcr:poznamka>testovací poznámka</amcr:poznamka>
-    <amcr:datum_nalezu>2024-06-01</amcr:datum_nalezu>
-    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>
-      <amcr:lokalizace>u lesa</amcr:lokalizace>
       <amcr:geom_wkt EPSG="4326">POINT(14.42 50.08)</amcr:geom_wkt>
     </amcr:chranene_udaje>
   </amcr:samostatny_nalez>

--- a/webclient/pas/tests/data/minimal_nalez_sjtsk.xml
+++ b/webclient/pas/tests/data/minimal_nalez_sjtsk.xml
@@ -7,6 +7,7 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>5514</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/multiple_samostatny_nalez.xml
+++ b/webclient/pas/tests/data/multiple_samostatny_nalez.xml
@@ -7,6 +7,7 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY_1}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>
@@ -16,6 +17,7 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY_2}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/nalez_invalid_geom_wkt.xml
+++ b/webclient/pas/tests/data/nalez_invalid_geom_wkt.xml
@@ -7,17 +7,11 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
-    <amcr:hloubka>42</amcr:hloubka>
-    <amcr:presna_datace>raný středověk</amcr:presna_datace>
-    <amcr:pocet>3</amcr:pocet>
-    <amcr:poznamka>testovací poznámka</amcr:poznamka>
-    <amcr:datum_nalezu>2024-06-01</amcr:datum_nalezu>
     <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>
-      <amcr:lokalizace>u lesa</amcr:lokalizace>
-      <amcr:geom_wkt EPSG="4326">POINT(14.42 50.08)</amcr:geom_wkt>
+      <amcr:geom_wkt EPSG="4326">NOT_VALID_WKT</amcr:geom_wkt>
     </amcr:chranene_udaje>
   </amcr:samostatny_nalez>
 </amcr:amcr>

--- a/webclient/pas/tests/data/nalez_invalid_stav.xml
+++ b/webclient/pas/tests/data/nalez_invalid_stav.xml
@@ -7,16 +7,10 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
-    <amcr:hloubka>42</amcr:hloubka>
-    <amcr:presna_datace>raný středověk</amcr:presna_datace>
-    <amcr:pocet>3</amcr:pocet>
-    <amcr:poznamka>testovací poznámka</amcr:poznamka>
-    <amcr:datum_nalezu>2024-06-01</amcr:datum_nalezu>
-    <amcr:stav>3</amcr:stav>
+    <amcr:stav>99</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>
-      <amcr:lokalizace>u lesa</amcr:lokalizace>
       <amcr:geom_wkt EPSG="4326">POINT(14.42 50.08)</amcr:geom_wkt>
     </amcr:chranene_udaje>
   </amcr:samostatny_nalez>

--- a/webclient/pas/tests/data/nalez_known_nalezce.xml
+++ b/webclient/pas/tests/data/nalez_known_nalezce.xml
@@ -4,6 +4,7 @@
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
     <amcr:nalezce id="{NALEZCE_IDENT}">{NALEZCE_LABEL}</amcr:nalezce>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost xml:lang="cs" id="{PRISTUPNOST_IDENT}">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/nalez_lang_ignored.xml
+++ b/webclient/pas/tests/data/nalez_lang_ignored.xml
@@ -3,6 +3,7 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost xml:lang="en" id="{PRISTUPNOST_IDENT}">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/nalez_linestring_geom_wkt.xml
+++ b/webclient/pas/tests/data/nalez_linestring_geom_wkt.xml
@@ -7,17 +7,11 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
-    <amcr:hloubka>42</amcr:hloubka>
-    <amcr:presna_datace>raný středověk</amcr:presna_datace>
-    <amcr:pocet>3</amcr:pocet>
-    <amcr:poznamka>testovací poznámka</amcr:poznamka>
-    <amcr:datum_nalezu>2024-06-01</amcr:datum_nalezu>
     <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>
-      <amcr:lokalizace>u lesa</amcr:lokalizace>
-      <amcr:geom_wkt EPSG="4326">POINT(14.42 50.08)</amcr:geom_wkt>
+      <amcr:geom_wkt EPSG="4326">LINESTRING(14.0 50.0, 15.0 51.0)</amcr:geom_wkt>
     </amcr:chranene_udaje>
   </amcr:samostatny_nalez>
 </amcr:amcr>

--- a/webclient/pas/tests/data/nalez_nonexistent_nalezce.xml
+++ b/webclient/pas/tests/data/nalez_nonexistent_nalezce.xml
@@ -4,6 +4,7 @@
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
     <amcr:nalezce id="OS-NEEXISTUJE">Neexistující, Osoba</amcr:nalezce>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost xml:lang="cs" id="{PRISTUPNOST_IDENT}">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/nalez_tba_nalezce.xml
+++ b/webclient/pas/tests/data/nalez_tba_nalezce.xml
@@ -4,6 +4,7 @@
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
     <amcr:nalezce id=":tba">Novák, Jan</amcr:nalezce>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost xml:lang="cs" id="{PRISTUPNOST_IDENT}">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/nalez_tba_nalezce_invalid_format.xml
+++ b/webclient/pas/tests/data/nalez_tba_nalezce_invalid_format.xml
@@ -4,6 +4,7 @@
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
     <amcr:nalezce id=":tba">Jan Novák</amcr:nalezce>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost xml:lang="cs" id="{PRISTUPNOST_IDENT}">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/nalez_with_igsn.xml
+++ b/webclient/pas/tests/data/nalez_with_igsn.xml
@@ -6,18 +6,13 @@
                                http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
+    <amcr:igsn>TEST-IGSN-001</amcr:igsn>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
-    <amcr:hloubka>42</amcr:hloubka>
-    <amcr:presna_datace>raný středověk</amcr:presna_datace>
-    <amcr:pocet>3</amcr:pocet>
-    <amcr:poznamka>testovací poznámka</amcr:poznamka>
-    <amcr:datum_nalezu>2024-06-01</amcr:datum_nalezu>
     <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>
-      <amcr:lokalizace>u lesa</amcr:lokalizace>
-      <amcr:geom_wkt EPSG="4326">POINT(14.42 50.08)</amcr:geom_wkt>
+      <amcr:geom_wkt EPSG="4326">POINT(14.0667 50.0333)</amcr:geom_wkt>
     </amcr:chranene_udaje>
   </amcr:samostatny_nalez>
 </amcr:amcr>

--- a/webclient/pas/tests/data/nalez_with_obdobi.xml
+++ b/webclient/pas/tests/data/nalez_with_obdobi.xml
@@ -8,6 +8,7 @@
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
     <amcr:obdobi id="{OBDOBI_IDENT}" xml:lang="cs">{OBDOBI_IDENT}</amcr:obdobi>
+    <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>

--- a/webclient/pas/tests/data/nalez_with_wrong_katastr_and_okres.xml
+++ b/webclient/pas/tests/data/nalez_with_wrong_katastr_and_okres.xml
@@ -7,17 +7,13 @@
   <amcr:samostatny_nalez>
     <amcr:ident_cely>{IDENT_CELY}</amcr:ident_cely>
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
-    <amcr:hloubka>42</amcr:hloubka>
-    <amcr:presna_datace>raný středověk</amcr:presna_datace>
-    <amcr:pocet>3</amcr:pocet>
-    <amcr:poznamka>testovací poznámka</amcr:poznamka>
-    <amcr:datum_nalezu>2024-06-01</amcr:datum_nalezu>
+    <amcr:okres id="{WRONG_OKRES_IDENT}" xml:lang="cs">{WRONG_OKRES_IDENT}</amcr:okres>
     <amcr:stav>3</amcr:stav>
     <amcr:geom_system>4326</amcr:geom_system>
     <amcr:pristupnost id="{PRISTUPNOST_IDENT}" xml:lang="cs">{PRISTUPNOST_IDENT}</amcr:pristupnost>
     <amcr:chranene_udaje>
-      <amcr:lokalizace>u lesa</amcr:lokalizace>
-      <amcr:geom_wkt EPSG="4326">POINT(14.42 50.08)</amcr:geom_wkt>
+      <amcr:katastr id="{WRONG_KATASTR_IDENT}" xml:lang="cs">{WRONG_KATASTR_IDENT}</amcr:katastr>
+      <amcr:geom_wkt EPSG="4326">POINT(14.0667 50.0333)</amcr:geom_wkt>
     </amcr:chranene_udaje>
   </amcr:samostatny_nalez>
 </amcr:amcr>

--- a/webclient/pas/tests/data/valid_file.xml
+++ b/webclient/pas/tests/data/valid_file.xml
@@ -5,6 +5,7 @@
     <amcr:projekt id="{PROJEKT_IDENT}">{PROJEKT_IDENT}</amcr:projekt>
     <amcr:hloubka>21</amcr:hloubka>
     <amcr:datum_nalezu>2026-04-06</amcr:datum_nalezu>
+    <amcr:stav>3</amcr:stav>
     <amcr:predano>false</amcr:predano>
     <amcr:predano_organizace xml:lang="cs" id="{PREDANO_ORGANIZACE_IDENT}">{PREDANO_ORGANIZACE_IDENT}</amcr:predano_organizace>
     <amcr:geom_system>4326</amcr:geom_system>

--- a/webclient/pas/tests/test_api.py
+++ b/webclient/pas/tests/test_api.py
@@ -22,6 +22,8 @@ from core.constants import (
     ODESLANI_SN,
     POTVRZENI_SN,
     SN_ARCHIVOVANY,
+    SN_ODESLANY,
+    SN_POTVRZENY,
     SN_ZAPSANY,
     ZAPSANI_SN,
 )
@@ -30,7 +32,7 @@ from core.repository_connector import FedoraNoResponseError
 from core.setting_models import CustomAdminSettings
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.db import DatabaseError
+from django.db import DatabaseError, IntegrityError
 from django.test import TestCase
 from django.urls import reverse
 from heslar.hesla import HESLAR_LICENCE, HESLAR_ORGANIZACE_TYP, HESLAR_PRISTUPNOST
@@ -43,7 +45,6 @@ from pas.api import (
     ImportErrorType,
     ImportValidationException,
     SamostatnyNalezEvidencniCisloPatchView,
-    SamostatnyNalezXmlBaseView,
     SamostatnyNalezXmlImportView,
 )
 from pas.models import SamostatnyNalez
@@ -155,11 +156,15 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         return connector
 
     def _clear_pas_api_settings(self) -> None:
-        """Vyčistí testovací ``CustomAdminSettings`` a cache pro PAS API."""
+        """Vyčistí testovací ``CustomAdminSettings``, cache a in-process slovník XSD pro PAS API."""
+        import pas.api
+
         CustomAdminSettings.objects.filter(item_group="pas_api").delete()
         cache.delete("pas_api_access_rules")
         cache.delete("pas_api_rate_limits")
         cache.delete("pas_api_access_mode")
+        cache.delete("pas_api_allowed_schema_versions")
+        pas.api._XSD_BYTES_CACHE.clear()
 
     @classmethod
     def _load_xml(cls, filename: str) -> bytes:
@@ -180,6 +185,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         pristupnost_ident: str,
         geom_system: str = "4326",
         geom_wkt: str = "POINT(14.0667 50.0333)",
+        stav: int = 3,
     ) -> bytes:
         """
         Sestaví minimální validní XML pro jeden ``amcr:samostatny_nalez`` ze šablony.
@@ -189,6 +195,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         :param pristupnost_ident: ``ident_cely`` hesláře přístupnosti.
         :param geom_system: Souřadnicový systém (``"4326"`` nebo ``"5514"``).
         :param geom_wkt: WKT geometrie bodu.
+        :param stav: Cílový stav záznamu (1, 2 nebo 3).
 
         :return: Vrací XML dokument jako bajty.
         """
@@ -200,6 +207,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
             GEOM_SYSTEM=geom_system,
             EPSG=geom_system,
             GEOM_WKT=geom_wkt,
+            STAV=stav,
         ).encode("utf-8")
 
     def _post_xml(
@@ -322,12 +330,6 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
                 "ownership": Permissions.ownershipChoices.our,
             },
         )
-        Permissions.objects.get_or_create(
-            main_role=badatel_group,
-            action=Permissions.actionChoices.model_edit,
-            defaults={"address_in_app": "heslar/osoba/zapsat", "base": True},
-        )
-
         with patch(
             "core.repository_connector.FedoraRepositoryConnector.check_container_deleted_or_not_exists",
             return_value=True,
@@ -479,11 +481,39 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         cls.projekt = Projekt.objects.get(ident_cely="M-202400099A")
         cls.non_survey_projekt = Projekt.objects.get(ident_cely="M-202400099B")
 
+        from django.contrib.gis.geos import MultiPolygon, Point, Polygon
+        from heslar.models import RuianOkres
+
+        cls.other_katastr_okres, _ = RuianOkres.objects.get_or_create(
+            kod=9998,
+            defaults={
+                "nazev": "Jiný testovací okres",
+                "nazev_en": "Other Test District",
+                "spz": "OT",
+                "kraj": RuianKatastr.objects.get(kod=999999).okres.kraj,
+                "definicni_bod": Point(10.0, 47.0, srid=4326),
+                "hranice": MultiPolygon(
+                    Polygon(((9.0, 46.5), (11.0, 46.5), (11.0, 47.5), (9.0, 47.5), (9.0, 46.5))), srid=4326
+                ),
+            },
+        )
+        cls.other_katastr, _ = RuianKatastr.objects.get_or_create(
+            kod=999998,
+            defaults={
+                "nazev": "Jiný testovací katastr",
+                "okres": cls.other_katastr_okres,
+                "definicni_bod": Point(10.0, 47.0, srid=4326),
+                "hranice": MultiPolygon(
+                    Polygon(((9.0, 46.5), (11.0, 46.5), (11.0, 47.5), (9.0, 47.5), (9.0, 46.5))), srid=4326
+                ),
+            },
+        )
+
     def test_access_mode_closed_returns_503(self):
         """Režim ``closed`` vrátí HTTP 503 ještě před vstupem do DRF permission vrstvy."""
         self._set_pas_api_setting("access_mode", "closed")
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-CLOSED-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -492,7 +522,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
         self.assertEqual(ApiRequestLog.objects.count(), 0)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-CLOSED-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
 
     def test_access_mode_open_ignores_whitelist_rules(self):
         """Režim ``open`` ignoruje whitelist pravidla a API zůstává dostupné."""
@@ -502,15 +532,15 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
             [{"rule_type": "user_whitelist", "value": "other@example.com", "active": True}],
         )
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-OPEN-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
 
         response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-OPEN-001")
-        self.assertTrue(SamostatnyNalez.objects.filter(ident_cely="SN-XML-OPEN-001").exists())
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self._assert_log_success()
 
     def test_access_mode_whitelist_only_allows_whitelisted_user(self):
@@ -521,22 +551,22 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
             [{"rule_type": "user_whitelist", "value": self.user.email, "active": True}],
         )
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-WHITELIST-ALLOW-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
 
         response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-WHITELIST-ALLOW-001")
-        self.assertTrue(SamostatnyNalez.objects.filter(ident_cely="SN-XML-WHITELIST-ALLOW-001").exists())
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self._assert_log_success()
 
     def test_access_mode_whitelist_only_without_whitelist_returns_403(self):
         """Režim ``whitelist_only`` bez whitelist pravidel odmítne požadavek."""
         self._set_pas_api_setting("access_mode", "whitelist_only")
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-WHITELIST-REQUIRED-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -545,12 +575,12 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(ApiRequestLog.objects.count(), 0)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-WHITELIST-REQUIRED-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
 
     def test_content_digest_mismatch_returns_400(self):
         """POST s neodpovídající hlavičkou ``Content-Digest`` vrátí HTTP 400."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BADDIGEST-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -563,7 +593,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_content_digest_invalid_format_returns_400(self):
         """POST s hlavičkou ``Content-Digest`` v neplatném formátu vrátí HTTP 400."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BADDIGEST-FORMAT-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -585,44 +615,38 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """Paralelní volání ``_get_amcr_schema`` zkompiluje schéma právě jednou."""
         original_schema_cache = dict(SamostatnyNalezXmlImportView._amcr_schema_cache)
         SamostatnyNalezXmlImportView._amcr_schema_cache = {}
-        schema_doc = object()
         schema_instance = object()
         schema_url = "https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd"
         doc = etree.ElementTree(
             etree.fromstring(
                 self._minimal_nalez_xml(
-                    ident_cely="SN-XML-SCHEMA-001",
+                    ident_cely=":tba",
                     projekt_ident=self.projekt.ident_cely,
                     pristupnost_ident=self.pristupnost.ident_cely,
                 )
             )
         )
 
-        def build_schema(doc):
+        def build_schema(schema_doc):
             time.sleep(0.05)
-            self.assertIs(doc, schema_doc)
             return schema_instance
 
         try:
-            with patch("pas.api.etree.parse", return_value=schema_doc) as parse_mock, patch(
-                "pas.api.urllib.request.urlopen"
-            ) as urlopen_mock, patch("pas.api.etree.XMLSchema", side_effect=build_schema) as xmlschema_mock:
-                urlopen_mock.return_value.__enter__.return_value = object()
-
+            with patch("pas.api._fetch_xsd_bytes", return_value=b"<schema/>") as fetch_mock, patch(
+                "pas.api.etree.XMLSchema", side_effect=build_schema
+            ) as xmlschema_mock:
                 with ThreadPoolExecutor(max_workers=8) as executor:
                     results = list(executor.map(lambda _: SamostatnyNalezXmlImportView._get_amcr_schema(doc), range(8)))
 
                 self.assertEqual(results, [schema_instance] * 8)
                 cached_schema, _ = SamostatnyNalezXmlImportView._amcr_schema_cache[schema_url]
                 self.assertIs(cached_schema, schema_instance)
-                urlopen_mock.assert_called_once_with(schema_url, timeout=10)
-                parse_mock.assert_called_once()
-                xmlschema_mock.assert_called_once_with(schema_doc)
+                fetch_mock.assert_called_once_with(schema_url)
+                xmlschema_mock.assert_called_once()
 
                 self.assertIs(SamostatnyNalezXmlImportView._get_amcr_schema(doc), schema_instance)
-                urlopen_mock.assert_called_once_with(schema_url, timeout=10)
-                parse_mock.assert_called_once()
-                xmlschema_mock.assert_called_once_with(schema_doc)
+                fetch_mock.assert_called_once_with(schema_url)
+                xmlschema_mock.assert_called_once()
         finally:
             SamostatnyNalezXmlImportView._amcr_schema_cache = original_schema_cache
 
@@ -631,7 +655,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         doc = etree.ElementTree(
             etree.fromstring(
                 self._minimal_nalez_xml(
-                    ident_cely="SN-XML-SCHEMA-BAD-001",
+                    ident_cely=":tba",
                     projekt_ident=self.projekt.ident_cely,
                     pristupnost_ident=self.pristupnost.ident_cely,
                 ).replace(
@@ -649,7 +673,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
     def test_local_resolver_rejects_disallowed_url_in_xsd_import(self):
         """Resolver odmítne nepovolenou URL v ``xs:import`` uvnitř staženého XSD jako ``INVALID_DATA``."""
-        xsd_with_disallowed_import = io.BytesIO(
+        evil_xsd_bytes = (
             b'<?xml version="1.0" encoding="UTF-8"?>'
             b'<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">'
             b'  <xs:import namespace="urn:evil" schemaLocation="https://evil.example/evil.xsd"/>'
@@ -658,7 +682,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         doc = etree.ElementTree(
             etree.fromstring(
                 self._minimal_nalez_xml(
-                    ident_cely="SN-XML-RESOLVER-BAD-001",
+                    ident_cely=":tba",
                     projekt_ident=self.projekt.ident_cely,
                     pristupnost_ident=self.pristupnost.ident_cely,
                 )
@@ -668,7 +692,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         original_schema_cache = dict(SamostatnyNalezXmlImportView._amcr_schema_cache)
         SamostatnyNalezXmlImportView._amcr_schema_cache = {}
         try:
-            with patch("pas.api.urllib.request.urlopen", return_value=xsd_with_disallowed_import):
+            with patch("pas.api._fetch_xsd_bytes", return_value=evil_xsd_bytes):
                 with self.assertRaises(ImportValidationException) as exc_ctx:
                     SamostatnyNalezXmlImportView._get_amcr_schema(doc)
         finally:
@@ -688,20 +712,20 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_heslar_wrong_group_returns_422(self):
         """Import vrátí HTTP 422, pokud atribut ``id`` odkazuje na položku z jiné skupiny hesláře."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-HES-GROUP-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         ).decode("utf-8")
         xml = xml.replace(
-            "<amcr:geom_system>",
-            f'<amcr:okolnosti id="{self.obdobi.ident_cely}" xml:lang="cs">{self.obdobi.heslo}</amcr:okolnosti>\n    <amcr:geom_system>',
+            "<amcr:stav>",
+            f'<amcr:okolnosti id="{self.obdobi.ident_cely}" xml:lang="cs">{self.obdobi.heslo}</amcr:okolnosti>\n    <amcr:stav>',
         ).encode("utf-8")
 
         response = self._post_xml(xml)
 
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn("validation_errors", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-HES-GROUP-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure(response.data)
 
     def test_invalid_token_returns_401(self):
@@ -720,7 +744,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_missing_content_digest_returns_400(self):
         """POST bez hlavičky ``Content-Digest`` vrátí HTTP 400."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-NODIGEST-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -741,7 +765,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_missing_projekt_returns_422(self):
         """XML bez elementu ``projekt`` vrátí HTTP 422 jako datovou chybu."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BAD-MISSING-PROJEKT",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         ).decode("utf-8")
@@ -760,8 +784,8 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """XML s více elementy ``amcr:samostatny_nalez`` vrátí HTTP 422."""
         template = self._load_xml("multiple_samostatny_nalez.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY_1="SN-XML-MULTI-001",
-            IDENT_CELY_2="SN-XML-MULTI-002",
+            IDENT_CELY_1=":tba",
+            IDENT_CELY_2=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
@@ -770,14 +794,13 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertTrue("detail" in response.data or "schema_errors" in response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-MULTI-001").exists())
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-MULTI-002").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure()
 
     def test_invalid_root_content_returns_422(self):
         """XML s dalším kořenovým potomkem kromě ``amcr:samostatny_nalez`` vrátí HTTP 422."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-ROOT-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         ).decode("utf-8")
@@ -794,14 +817,14 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn("detail", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-ROOT-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure(response.data)
 
     def test_nonexistent_nalezce_returns_404(self):
         """XML s neexistujícím ``nalezce`` vrátí HTTP 404."""
         template = self._load_xml("nalez_nonexistent_nalezce.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-OS-BAD-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
@@ -810,13 +833,13 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("validation_errors", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-OS-BAD-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure()
 
     def test_nonexistent_pristupnost_returns_422(self):
         """XML s neexistujícím heslem přístupnosti vrátí HTTP 422."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BAD-2",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident="HES-NEEXISTUJE",
         )
@@ -828,7 +851,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_nonexistent_projekt_returns_404(self):
         """XML s neexistujícím projektem vrátí HTTP 404."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BAD-1",
+            ident_cely=":tba",
             projekt_ident="NEEXISTUJE-9999",
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -840,7 +863,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_non_survey_projekt_returns_404(self):
         """XML s projektem mimo typ ``průzkum`` vrátí HTTP 404 stejně jako neexistující projekt."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BAD-NON-SURVEY-001",
+            ident_cely=":tba",
             projekt_ident=self.non_survey_projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -849,7 +872,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("validation_errors", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-BAD-NON-SURVEY-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.non_survey_projekt).exists())
         self._assert_log_failure()
 
     def test_schema_invalid_xml_returns_422(self):
@@ -859,11 +882,77 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         self.assertIn("schema_errors", response.data)
         self._assert_log_failure()
 
-    def test_stav_element_returns_422(self):
-        """POST s nepovoleným elementem ``stav`` vrátí HTTP 422."""
-        template = self._load_xml("nalez_with_stav.xml").decode("utf-8")
+    def test_allowed_schema_versions_rejects_disallowed_version(self):
+        """Import s verzí schématu, která není v ``allowed_schema_versions``, vrátí HTTP 422."""
+        self._set_pas_api_setting("allowed_schema_versions", [9.9])
+        xml = self._minimal_nalez_xml(
+            ident_cely=":tba",
+            projekt_ident=self.projekt.ident_cely,
+            pristupnost_ident=self.pristupnost.ident_cely,
+        )
+
+        response = self._post_xml(xml)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("detail", response.data)
+        self.assertIn("version_not_allowed", response.data["detail"])
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
+        self._assert_log_failure(response.data)
+
+    def test_allowed_schema_versions_accepts_listed_version(self):
+        """Import s verzí schématu obsaženou v ``allowed_schema_versions`` proběhne úspěšně."""
+        self._set_pas_api_setting("allowed_schema_versions", [2.2])
+        xml = self._minimal_nalez_xml(
+            ident_cely=":tba",
+            projekt_ident=self.projekt.ident_cely,
+            pristupnost_ident=self.pristupnost.ident_cely,
+        )
+
+        response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self._assert_log_success()
+
+    def test_allowed_schema_versions_not_set_accepts_any_version(self):
+        """Import bez nastavení ``allowed_schema_versions`` v DB neomezuje verzi schématu."""
+        xml = self._minimal_nalez_xml(
+            ident_cely=":tba",
+            projekt_ident=self.projekt.ident_cely,
+            pristupnost_ident=self.pristupnost.ident_cely,
+        )
+
+        response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self._assert_log_success()
+
+    def test_missing_stav_fails_xsd_validation(self):
+        """POST s jinak validním XML bez elementu ``stav`` vrátí HTTP 422 s chybou validace XSD schématu."""
+        template = self._load_xml("minimal_nalez_no_stav.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-STAV-001",
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+        ).encode("utf-8")
+
+        response = self._post_xml(xml)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("schema_errors", response.data)
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
+        self._assert_log_failure()
+
+    def test_out_of_range_stav_in_xml_returns_422(self):
+        """Import s hodnotou ``stav=99`` v XML vrátí HTTP 422 a záznam se nevytvoří.
+
+        XSD validace neomezuje hodnotu ``stav`` výčtem — hodnota 99 projde schématem.
+        Import ji odmítne jako nepodporovanou hodnotu (povoleny jsou pouze 1, 2, 3).
+        """
+        template = self._load_xml("nalez_invalid_stav.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
@@ -872,8 +961,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn("validation_errors", response.data)
-        self.assertEqual(response.data["validation_errors"][0]["error_type"], ImportErrorType.INVALID_DATA.value)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-STAV-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure()
 
     def test_tba_ident_cely_is_generated_automatically(self):
@@ -893,11 +981,141 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         self.assertIn(nalez.ident_cely, response.content.decode("utf-8"))
         self._assert_log_success()
 
+    def test_non_tba_ident_cely_returns_422(self):
+        """Import s hodnotou ``ident_cely`` jinou než ``:tba`` vrátí HTTP 422."""
+        xml = self._minimal_nalez_xml(
+            ident_cely="SN-XML-EXPLICIT-001",
+            projekt_ident=self.projekt.ident_cely,
+            pristupnost_ident=self.pristupnost.ident_cely,
+        )
+
+        response = self._post_xml(xml)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("validation_errors", response.data)
+        self.assertEqual(response.data["validation_errors"][0]["error_type"], ImportErrorType.INVALID_DATA.value)
+        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-EXPLICIT-001").exists())
+        self._assert_log_failure()
+
+    def test_igsn_in_xml_is_ignored(self):
+        """Import s polem ``igsn`` v XML vytvoří záznam, ale ``igsn`` pole záznamu zůstane prázdné."""
+        template = self._load_xml("nalez_with_igsn.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+        ).encode("utf-8")
+
+        response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self.assertFalse(nalez.igsn)
+        self._assert_log_success()
+
+    def test_katastr_in_xml_is_ignored_uses_coordinates(self):
+        """Import s ``katastr`` polem v ``chranene_udaje`` XML ignoruje XML hodnotu a doplní katastr ze souřadnic.
+
+        XML uvádí jiný katastr než odpovídá souřadnicím ``geom_wkt``. Importovaný záznam
+        musí mít katastr odvozený ze souřadnic, nikoliv z XML pole.
+        """
+        template = self._load_xml("nalez_with_wrong_katastr_and_okres.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+            WRONG_KATASTR_IDENT=f"ruian-{self.other_katastr.kod}",
+            WRONG_OKRES_IDENT=f"ruian-{self.other_katastr_okres.kod}",
+        ).encode("utf-8")
+
+        response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self.assertEqual(nalez.katastr.kod, 999999)
+        self.assertNotEqual(nalez.katastr.kod, self.other_katastr.kod)
+        self._assert_log_success()
+
+    def test_okres_in_xml_is_ignored_derived_from_katastr(self):
+        """Import s ``okres`` polem v XML ignoruje XML hodnotu a okres je odvozen z katastru ze souřadnic.
+
+        XML uvádí jiný okres než odpovídá katastru odvozenému ze souřadnic ``geom_wkt``. Importovaný
+        záznam musí mít katastr odvozený ze souřadnic a tedy i správný okres z tohoto katastru.
+        """
+        template = self._load_xml("nalez_with_wrong_katastr_and_okres.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+            WRONG_KATASTR_IDENT=f"ruian-{self.other_katastr.kod}",
+            WRONG_OKRES_IDENT=f"ruian-{self.other_katastr_okres.kod}",
+        ).encode("utf-8")
+
+        response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self.assertEqual(nalez.katastr.okres.kod, 9999)
+        self.assertNotEqual(nalez.katastr.okres.kod, self.other_katastr_okres.kod)
+        self._assert_log_success()
+
+    def test_invalid_geom_wkt_returns_422(self):
+        """Import s syntakticky neplatným WKT v ``geom_wkt`` vrátí HTTP 422."""
+        template = self._load_xml("nalez_invalid_geom_wkt.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+        ).encode("utf-8")
+
+        response = self._post_xml(xml)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("validation_errors", response.data)
+        self.assertEqual(response.data["validation_errors"][0]["error_type"], ImportErrorType.INVALID_DATA.value)
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
+        self._assert_log_failure()
+
+    def test_non_point_geom_wkt_returns_422(self):
+        """Import s WKT geometrií jiného typu než ``Point`` v ``geom_wkt`` vrátí HTTP 422."""
+        template = self._load_xml("nalez_linestring_geom_wkt.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+        ).encode("utf-8")
+
+        response = self._post_xml(xml)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("validation_errors", response.data)
+        self.assertEqual(response.data["validation_errors"][0]["error_type"], ImportErrorType.INVALID_DATA.value)
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
+        self._assert_log_failure()
+
+    def test_invalid_geom_sjtsk_wkt_returns_422(self):
+        """Import s syntakticky neplatným WKT v ``geom_sjtsk_wkt`` vrátí HTTP 422."""
+        template = self._load_xml("minimal_nalez_sjtsk.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+            GEOM_SJTSK_WKT="NOT_VALID_WKT",
+        ).encode("utf-8")
+
+        response = self._post_xml(xml)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("validation_errors", response.data)
+        self.assertEqual(response.data["validation_errors"][0]["error_type"], ImportErrorType.INVALID_DATA.value)
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
+        self._assert_log_failure()
+
     def test_tba_nalezce_is_rolled_back_when_samostatny_nalez_save_fails(self):
         """Při chybě ukládání nálezu se vrátí HTTP 500 a nově vytvořená osoba se vrátí rollbackem."""
         template = self._load_xml("nalez_tba_nalezce.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-TBA-ROLLBACK-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
@@ -920,20 +1138,20 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
             {"detail": "pas.api.SamostatnyNalezXmlImportView.post.internal_error"},
         )
         self.assertFalse(Osoba.objects.filter(prijmeni="Novák", jmeno="Jan").exists())
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-TBA-ROLLBACK-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure(response.data)
 
     def test_get_metadata_failure_returns_500_with_failed_log(self):
         """Selhání čtení metadat z Fedory po uložení záznamu vrátí HTTP 500 a uzavře API log jako neúspěšný."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-METADATA-FAIL-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
 
         connector = Mock()
         connector.get_metadata.side_effect = FedoraNoResponseError(
-            "http://fedora.example/rest/record/SN-XML-METADATA-FAIL-001",
+            "http://fedora.example/rest/record",
             "No Fedora response",
             None,
         )
@@ -946,14 +1164,14 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
             response.data,
             {"detail": "pas.api.SamostatnyNalezXmlImportView.post.fedor_error_reading_data_after_saving"},
         )
-        self.assertTrue(SamostatnyNalez.objects.filter(ident_cely="SN-XML-METADATA-FAIL-001").exists())
+        self.assertTrue(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure(response.data)
 
     def test_tba_nalezce_with_invalid_format_returns_422(self):
         """Import s ``nalezce id=":tba"`` a nevalidním formátem vrátí HTTP 422."""
         template = self._load_xml("nalez_tba_nalezce_invalid_format.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-TBA-BAD-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
@@ -963,31 +1181,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn("validation_errors", response.data)
         self.assertFalse(Osoba.objects.filter(jmeno="Jan", prijmeni="Novák").exists())
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-TBA-BAD-001").exists())
-        self._assert_log_failure()
-
-    def test_tba_nalezce_without_model_edit_permission_returns_403(self):
-        """Import s ``nalezce id=":tba"`` bez oprávnění na vytvoření osoby vrátí HTTP 403."""
-        template = self._load_xml("nalez_tba_nalezce.xml").decode("utf-8")
-        xml = template.format(
-            IDENT_CELY="SN-XML-TBA-002",
-            PROJEKT_IDENT=self.projekt.ident_cely,
-            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
-        ).encode("utf-8")
-
-        def permission_side_effect(action, user, ident=None):
-            if action == Permissions.actionChoices.model_edit:
-                return False
-            return True
-
-        with patch("pas.api.check_permissions", side_effect=permission_side_effect):
-            response = self._post_xml(xml)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertIn("validation_errors", response.data)
-        self.assertEqual(response.data["validation_errors"][0]["error_type"], ImportErrorType.PERMISSION_ERROR.value)
-        self.assertFalse(Osoba.objects.filter(prijmeni="Novák", jmeno="Jan").exists())
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-TBA-002").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure()
 
     def test_unauthenticated_returns_401(self):
@@ -1002,7 +1196,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_user_without_pas_edit_permission_returns_403(self):
         """Uživatel bez oprávnění ``pas_edit`` obdrží HTTP 403."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-FORBIDDEN-002",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -1021,13 +1215,13 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertIn("detail", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-FORBIDDEN-002").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure()
 
     def test_user_without_pas_ulozeni_edit_permission_returns_403(self):
         """Uživatel bez oprávnění ``pas_ulozeni_edit`` obdrží HTTP 403."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-FORBIDDEN-ULOZENI-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -1046,13 +1240,13 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertIn("detail", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-FORBIDDEN-ULOZENI-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure()
 
     def test_user_without_project_permission_returns_403(self):
         """Uživatel bez oprávnění ``pas_zapsat_do_projektu`` pro daný projekt obdrží HTTP 403."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-FORBIDDEN-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
@@ -1069,21 +1263,21 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertIn("detail", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-FORBIDDEN-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure()
 
     def test_valid_file_xml_creates_record_with_correct_values(self):
         """Import souboru ``valid_file.xml`` vytvoří záznam a importovaná data odpovídají obsahu XML."""
         template = self._load_xml("valid_file.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-VF-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
             PREDANO_ORGANIZACE_IDENT=self.organizace.ident_cely,
         ).encode("utf-8")
         response = self._post_xml(xml)
-        self._assert_xml_success_response(response, "SN-XML-VF-001")
-        nalez = SamostatnyNalez.objects.get(ident_cely="SN-XML-VF-001")
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self.assertEqual(nalez.hloubka, 21)
         self.assertEqual(str(nalez.datum_nalezu), "2026-04-06")
         self.assertFalse(nalez.predano)
@@ -1094,21 +1288,21 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         self.assertAlmostEqual(nalez.geom.y, 49.9914407, places=5)
         self.assertAlmostEqual(nalez.geom_sjtsk.x, -828708.49, places=1)
         self.assertAlmostEqual(nalez.geom_sjtsk.y, -1041287.69, places=1)
-        self.assertEqual(nalez.stav, SamostatnyNalezXmlBaseView.XML_IMPORT_INITIAL_STAV)
+        self.assertEqual(nalez.stav, SN_POTVRZENY)
         self._assert_log_success()
 
     def test_valid_xml_creates_import_history_records(self):
         """Import vytvoří tři položky historie s importní poznámkou a vazbou na záznam."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-HIST-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
 
         response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-HIST-001")
-        nalez = SamostatnyNalez.objects.get(ident_cely="SN-XML-HIST-001")
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         historie = list(Historie.objects.filter(vazba=nalez.historie).order_by("datum_zmeny", "id"))
 
         self.assertEqual(len(historie), 3)
@@ -1118,51 +1312,58 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         self.assertTrue(all(item.vazba == nalez.historie for item in historie))
         self._assert_log_success()
 
+    def test_import_stav2_creates_only_two_history_records(self):
+        """Import se ``stav=2`` vytvoří pouze záznamy SN01 a SN12, nikoli SN23."""
+        xml = self._minimal_nalez_xml(
+            ident_cely=":tba",
+            projekt_ident=self.projekt.ident_cely,
+            pristupnost_ident=self.pristupnost.ident_cely,
+            stav=2,
+        )
+
+        response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self.assertEqual(nalez.stav, SN_ODESLANY)
+        historie = list(Historie.objects.filter(vazba=nalez.historie).order_by("datum_zmeny", "id"))
+        self.assertEqual(len(historie), 2)
+        self.assertEqual([item.typ_zmeny for item in historie], [ZAPSANI_SN, ODESLANI_SN])
+
+    def test_import_stav1_creates_only_one_history_record(self):
+        """Import se ``stav=1`` vytvoří pouze záznam SN01."""
+        xml = self._minimal_nalez_xml(
+            ident_cely=":tba",
+            projekt_ident=self.projekt.ident_cely,
+            pristupnost_ident=self.pristupnost.ident_cely,
+            stav=1,
+        )
+
+        response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self.assertEqual(nalez.stav, SN_ZAPSANY)
+        historie = list(Historie.objects.filter(vazba=nalez.historie).order_by("datum_zmeny", "id"))
+        self.assertEqual(len(historie), 1)
+        self.assertEqual([item.typ_zmeny for item in historie], [ZAPSANI_SN])
+
     def test_valid_xml_creates_record(self):
         """Validní XML s minimálními poli vytvoří záznam v databázi a vrátí HTTP 200."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
         response = self._post_xml(xml)
-        self._assert_xml_success_response(response, "SN-XML-001")
-        self.assertTrue(SamostatnyNalez.objects.filter(ident_cely="SN-XML-001").exists())
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self._assert_log_success()
-
-    def test_duplicate_ident_cely_returns_422(self):
-        """Opakovaný import stejného ``ident_cely`` vrátí validační chybu HTTP 422."""
-        xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-DUP-001",
-            projekt_ident=self.projekt.ident_cely,
-            pristupnost_ident=self.pristupnost.ident_cely,
-        )
-
-        first_response = self._post_xml(xml)
-
-        self._assert_xml_success_response(first_response, "SN-XML-DUP-001")
-        self.assertTrue(SamostatnyNalez.objects.filter(ident_cely="SN-XML-DUP-001").exists())
-
-        duplicate_response = self._post_xml(xml)
-
-        self.assertEqual(duplicate_response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
-        self.assertIn("validation_errors", duplicate_response.data)
-        self.assertEqual(
-            duplicate_response.data["validation_errors"][0]["error_type"], ImportErrorType.INVALID_DATA.value
-        )
-        self.assertEqual(SamostatnyNalez.objects.filter(ident_cely="SN-XML-DUP-001").count(), 1)
-
-        logs = list(ApiRequestLog.objects.order_by("received_at", "id"))
-        self.assertEqual(len(logs), 2)
-        self.assertEqual(logs[0].status, API_REQUEST_LOG_STATUS_SUCCESS)
-        self.assertEqual(logs[1].status, API_REQUEST_LOG_STATUS_FAILURE)
-        self.assertIsNotNone(logs[1].finished_at)
-        self.assertEqual(logs[1].errors, duplicate_response.data)
 
     def test_katastr_filled_from_geom_wkt(self):
         """Import s ``geom_system=4326`` doplní katastr ze souřadnic ``geom_wkt``."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-KATASTR-GEOM-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
             geom_wkt="POINT(14.0667 50.0333)",
@@ -1170,8 +1371,8 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-KATASTR-GEOM-001")
-        nalez = SamostatnyNalez.objects.get(ident_cely="SN-XML-KATASTR-GEOM-001")
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self.assertEqual(nalez.katastr, RuianKatastr.objects.get(kod=999999))
         self._assert_log_success()
 
@@ -1179,7 +1380,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """Import s ``geom_system=5514`` doplní katastr transformací ``geom_sjtsk_wkt`` do WGS-84."""
         template = self._load_xml("minimal_nalez_sjtsk.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-KATASTR-SJTSK-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
             # Transforms to WGS-84 POINT(14.0667 50.0333) — inside the test fixture polygon for kod=999999.
@@ -1188,8 +1389,8 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-KATASTR-SJTSK-001")
-        nalez = SamostatnyNalez.objects.get(ident_cely="SN-XML-KATASTR-SJTSK-001")
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self.assertEqual(nalez.katastr, RuianKatastr.objects.get(kod=999999))
         self._assert_log_success()
 
@@ -1197,7 +1398,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """Import vrátí HTTP 422, pokud XML neobsahuje žádnou geometrii."""
         template = self._load_xml("minimal_nalez_no_geom.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-NO-GEOM-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
@@ -1206,13 +1407,13 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn("validation_errors", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-NO-GEOM-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure(response.data)
 
     def test_geom_outside_cadastre_returns_422(self):
         """Import vrátí HTTP 422, pokud souřadnice nespadají do žádného katastru."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-NO-KATASTR-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
             # Coordinates in the Atlantic Ocean — outside any cadastre polygon.
@@ -1223,14 +1424,14 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn("validation_errors", response.data)
-        self.assertFalse(SamostatnyNalez.objects.filter(ident_cely="SN-XML-NO-KATASTR-001").exists())
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
         self._assert_log_failure(response.data)
 
     def test_valid_xml_with_known_nalezce_links_existing_osoba(self):
         """Import s existujícím ``nalezce`` naváže záznam na existující osobu."""
         template = self._load_xml("nalez_known_nalezce.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-OS-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
             NALEZCE_IDENT=self.known_osoba.ident_cely,
@@ -1239,8 +1440,8 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
 
         response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-OS-001")
-        nalez = SamostatnyNalez.objects.get(ident_cely="SN-XML-OS-001")
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self.assertEqual(nalez.nalezce, self.known_osoba)
         self._assert_log_success()
 
@@ -1248,13 +1449,13 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """XML s volitelnými poli (hloubka, poznamka, presna_datace) vytvoří záznam se správnými hodnotami."""
         template = self._load_xml("nalez_optional_fields.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-003",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
         response = self._post_xml(xml)
-        self._assert_xml_success_response(response, "SN-XML-003")
-        nalez = SamostatnyNalez.objects.get(ident_cely="SN-XML-003")
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self.assertEqual(nalez.hloubka, 42)
         self.assertEqual(nalez.poznamka, "testovací poznámka")
         self.assertEqual(nalez.lokalizace, "u lesa")
@@ -1265,7 +1466,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """Import s ``nalezce id=":tba"`` vytvoří novou osobu a naváže ji na nález."""
         template = self._load_xml("nalez_tba_nalezce.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-TBA-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
@@ -1276,14 +1477,70 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         ):
             response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-TBA-001")
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         osoba = Osoba.objects.get(prijmeni="Novák", jmeno="Jan")
-        nalez = SamostatnyNalez.objects.get(ident_cely="SN-XML-TBA-001")
 
         self.assertEqual(osoba.vypis_cely, "Novák, Jan")
         self.assertEqual(osoba.vypis, "Novák, J.")
         self.assertEqual(nalez.nalezce, osoba)
         self._assert_log_success()
+
+    def test_tba_nalezce_reuses_existing_osoba_when_name_matches(self):
+        """Import s ``nalezce id=":tba"`` použije existující osobu, pokud shodné jméno a příjmení již existují."""
+        with patch(
+            "core.repository_connector.FedoraRepositoryConnector.check_container_deleted_or_not_exists",
+            return_value=True,
+        ):
+            existing_osoba, _ = Osoba.objects.get_or_create(
+                prijmeni="Novák",
+                jmeno="Jan",
+                defaults={
+                    "vypis": "Novák, J.",
+                    "vypis_cely": "Novák, Jan",
+                },
+            )
+        osoba_count_before = Osoba.objects.count()
+        template = self._load_xml("nalez_tba_nalezce.xml").decode("utf-8")
+        xml = template.format(
+            IDENT_CELY=":tba",
+            PROJEKT_IDENT=self.projekt.ident_cely,
+            PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
+        ).encode("utf-8")
+
+        with patch(
+            "core.repository_connector.FedoraRepositoryConnector.check_container_deleted_or_not_exists",
+            return_value=True,
+        ):
+            response = self._post_xml(xml)
+
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
+        self.assertEqual(nalez.nalezce, existing_osoba)
+        self.assertEqual(Osoba.objects.count(), osoba_count_before)
+        self._assert_log_success()
+
+    def test_integrity_error_fallback_returns_422(self):
+        """``IntegrityError`` způsobená jiným omezením než ``osoba_jmeno_prijmeni_key`` vrátí HTTP 422.
+
+        Ověřuje fallback větev handleru: neznámé omezení integrity vrátí neutrální klíč chybové zprávy
+        místo detailní zprávy specifické pro duplicitní osobu.
+        """
+        xml = self._minimal_nalez_xml(
+            ident_cely=":tba",
+            projekt_ident=self.projekt.ident_cely,
+            pristupnost_ident=self.pristupnost.ident_cely,
+        )
+
+        with patch("pas.api.SamostatnyNalez.save", side_effect=IntegrityError("other constraint violated")):
+            response = self._post_xml(xml)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("detail", response.data)
+        self.assertIn("integrity_error", response.data["detail"])
+        self.assertNotIn("error", response.data)
+        self.assertFalse(SamostatnyNalez.objects.filter(projekt=self.projekt).exists())
+        self._assert_log_failure()
 
     def test_validate_schema_url_allowed_accepts_configured_prefixes(self):
         """Allowlist přijímá povolené URL rodiny pro W3C, AMČR a GML."""
@@ -1303,15 +1560,14 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_schema_fetch_network_error_returns_422(self):
         """Síťová chyba při načítání XSD schématu vrátí HTTP 422 místo 500."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-NETERR-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         )
-        # Vyčistíme cache schématu, aby se urlopen skutečně zavolal.
         SamostatnyNalezXmlImportView._amcr_schema_cache.clear()
 
         with patch(
-            "pas.api.urllib.request.urlopen",
+            "pas.api._fetch_xsd_bytes",
             side_effect=urllib.error.URLError("simulated network failure"),
         ):
             response = self._post_xml(xml)
@@ -1323,7 +1579,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_wrong_amcr_namespace_version_returns_422(self):
         """POST s deklarovaným AMČR namespace jiné verze vrátí HTTP 422."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BADNS-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         ).decode("utf-8")
@@ -1341,7 +1597,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
     def test_wrong_amcr_schema_location_version_returns_422(self):
         """POST s deklarovanou XSD URL jiné AMČR verze vrátí HTTP 422."""
         xml = self._minimal_nalez_xml(
-            ident_cely="SN-XML-BADXSD-001",
+            ident_cely=":tba",
             projekt_ident=self.projekt.ident_cely,
             pristupnost_ident=self.pristupnost.ident_cely,
         ).decode("utf-8")
@@ -1364,7 +1620,7 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """
         template = self._load_xml("nalez_with_obdobi.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-BAD-3",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
             OBDOBI_IDENT=self.licence.ident_cely,
@@ -1378,16 +1634,158 @@ class SamostatnyNalezXmlImportViewTests(TestCase):
         """Import s ``xml:lang`` odlišným od ``cs`` uspěje a vrátí poznámku o ignorování."""
         template = self._load_xml("nalez_lang_ignored.xml").decode("utf-8")
         xml = template.format(
-            IDENT_CELY="SN-XML-LANG-001",
+            IDENT_CELY=":tba",
             PROJEKT_IDENT=self.projekt.ident_cely,
             PRISTUPNOST_IDENT=self.pristupnost.ident_cely,
         ).encode("utf-8")
 
         response = self._post_xml(xml)
 
-        self._assert_xml_success_response(response, "SN-XML-LANG-001")
-        self.assertTrue(SamostatnyNalez.objects.filter(ident_cely="SN-XML-LANG-001").exists())
+        nalez = SamostatnyNalez.objects.get(projekt=self.projekt)
+        self._assert_xml_success_response(response, nalez.ident_cely)
         self._assert_log_success()
+
+
+class FetchXsdBytesTests(TestCase):
+    """Jednotkové testy pro ``_fetch_xsd_bytes`` a ``_xsd_redis_key``."""
+
+    def setUp(self):
+        """Vyčistí Redis cache a in-process slovník před každým testem."""
+        import pas.api
+
+        cache.clear()
+        pas.api._XSD_BYTES_CACHE.clear()
+
+    def tearDown(self):
+        """Vyčistí Redis cache a in-process slovník po každém testu."""
+        import pas.api
+
+        cache.clear()
+        pas.api._XSD_BYTES_CACHE.clear()
+
+    # --- _xsd_redis_key ---
+
+    def test_redis_key_amcr_url_includes_version(self):
+        """Klíč pro AMČR URL obsahuje číslo verze."""
+        from pas.api import _xsd_redis_key
+
+        key = _xsd_redis_key("https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd")
+        self.assertEqual(key, "xsd_schema:amcr:2.2:https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd")
+
+    def test_redis_key_amcr_url_different_version(self):
+        """Klíče pro různé verze AMČR schématu se liší."""
+        from pas.api import _xsd_redis_key
+
+        key_22 = _xsd_redis_key("https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd")
+        key_23 = _xsd_redis_key("https://api.aiscr.cz/schema/amcr/2.3/amcr.xsd")
+        self.assertNotEqual(key_22, key_23)
+        self.assertIn("2.2", key_22)
+        self.assertIn("2.3", key_23)
+
+    def test_redis_key_non_amcr_url_uses_full_url(self):
+        """Klíč pro W3C URL neobsahuje prefix verze."""
+        from pas.api import _xsd_redis_key
+
+        url = "https://www.w3.org/2001/xml.xsd"
+        key = _xsd_redis_key(url)
+        self.assertEqual(key, f"xsd_schema:{url}")
+
+    # --- _fetch_xsd_bytes ---
+
+    def test_returns_bytes_from_network_on_cache_miss(self):
+        """Při absenci záznamu v cache se bajty stáhnou ze sítě."""
+        from pas.api import _fetch_xsd_bytes
+
+        expected = b"<schema/>"
+        mock_response = io.BytesIO(expected)
+        with patch("pas.api.urllib.request.urlopen", return_value=mock_response) as urlopen_mock:
+            result = _fetch_xsd_bytes("https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd")
+
+        self.assertEqual(result, expected)
+        urlopen_mock.assert_called_once_with("https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd", timeout=10)
+
+    def test_stores_bytes_in_cache_after_network_fetch(self):
+        """Po stažení ze sítě se bajty uloží do cache."""
+        from pas.api import _fetch_xsd_bytes, _xsd_redis_key
+
+        url = "https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd"
+        expected = b"<schema/>"
+        with patch("pas.api.urllib.request.urlopen", return_value=io.BytesIO(expected)):
+            _fetch_xsd_bytes(url)
+
+        self.assertEqual(cache.get(_xsd_redis_key(url)), expected)
+
+    def test_returns_cached_bytes_without_network_call(self):
+        """Při zásahu cache se síť nevolá."""
+        from pas.api import _fetch_xsd_bytes, _xsd_redis_key
+
+        url = "https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd"
+        cached_bytes = b"<cached/>"
+        cache.set(_xsd_redis_key(url), cached_bytes)
+
+        with patch("pas.api.urllib.request.urlopen") as urlopen_mock:
+            result = _fetch_xsd_bytes(url)
+
+        self.assertEqual(result, cached_bytes)
+        urlopen_mock.assert_not_called()
+
+    def test_cache_hit_for_non_amcr_url(self):
+        """Cache funguje i pro W3C URL bez verze v klíči."""
+        from pas.api import _fetch_xsd_bytes, _xsd_redis_key
+
+        url = "https://www.w3.org/2001/xml.xsd"
+        cached_bytes = b"<xml-schema/>"
+        cache.set(_xsd_redis_key(url), cached_bytes)
+
+        with patch("pas.api.urllib.request.urlopen") as urlopen_mock:
+            result = _fetch_xsd_bytes(url)
+
+        self.assertEqual(result, cached_bytes)
+        urlopen_mock.assert_not_called()
+
+    def test_propagates_url_error(self):
+        """Síťová chyba se propaguje jako ``urllib.error.URLError``."""
+        from pas.api import _fetch_xsd_bytes
+
+        with patch(
+            "pas.api.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            with self.assertRaises(urllib.error.URLError):
+                _fetch_xsd_bytes("https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd")
+
+    def test_propagates_timeout_error(self):
+        """Vypršení časového limitu se propaguje jako ``TimeoutError``."""
+        from pas.api import _fetch_xsd_bytes
+
+        with patch("pas.api.urllib.request.urlopen", side_effect=TimeoutError()):
+            with self.assertRaises(TimeoutError):
+                _fetch_xsd_bytes("https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd")
+
+    def test_network_error_does_not_populate_cache(self):
+        """Při síťové chybě se do cache nic neuloží."""
+        from pas.api import _fetch_xsd_bytes, _xsd_redis_key
+
+        url = "https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd"
+        with patch("pas.api.urllib.request.urlopen", side_effect=urllib.error.URLError("err")):
+            try:
+                _fetch_xsd_bytes(url)
+            except urllib.error.URLError:
+                pass
+
+        self.assertIsNone(cache.get(_xsd_redis_key(url)))
+
+    def test_second_call_uses_cache(self):
+        """Druhé volání se stejnou URL neotevře síťové spojení znovu."""
+        from pas.api import _fetch_xsd_bytes
+
+        url = "https://api.aiscr.cz/schema/amcr/2.2/amcr.xsd"
+        content = b"<schema/>"
+        with patch("pas.api.urllib.request.urlopen", return_value=io.BytesIO(content)) as urlopen_mock:
+            _fetch_xsd_bytes(url)
+            _fetch_xsd_bytes(url)
+
+        urlopen_mock.assert_called_once()
 
 
 class SamostatnyNalezEvidencniCisloPatchViewTests(TestCase):


### PR DESCRIPTION
Opravy a úpravy XML importu samostatných nálezů navazující na testování v issue #3194.

## Změny

### Opravy chování importu
- **Geometrie** — při `geom_system=4326` se nyní bere jako zdroj výhradně `geom_wkt` a hodnota `geom_sjtsk` se dopočítá konverzí; při `geom_system=5514` analogicky ze `geom_sjtsk_wkt`. Dříve se ukládaly obě hodnoty ze vstupu, což vedlo k nekonzistencím a prázdným polím v DB.
- **Validace `geom_system`** — hodnota jiná než `4326` nebo `5514` nyní vrátí HTTP 422 místo dřívějšího HTTP 500.
- **Chybějící souřadnice** — pokud primární WKT element chybí nebo jsou souřadnice mimo rozsah konverze, vrátí se HTTP 422 s konkrétní chybovou zprávou místo HTTP 500.
- **`amcr:stav`** — element je vyžadován XSD schématem a importem přijat. Hodnota z XML určuje cílový stav záznamu (povoleny hodnoty 1, 2, 3; hodnota mimo tento rozsah vrátí HTTP 422). Záznamy historie se vytvářejí pouze pro přechody až do cílového stavu (stav 1 → SN01, stav 2 → SN01+SN12, stav 3 → SN01+SN12+SN23). Dříve byl element v importu zakázán.
- **`ident_cely`** — hodnota jiná než `:tba` je explicitně odmítnuta s HTTP 422. Hodnota `:tba` projde validací, ale do DB se vždy uloží automaticky vygenerovaný identifikátor (`get_sn_ident`); `:tba` slouží pouze jako signál, že volající identifikátor nepřiděluje.
- **IGSN a ignorované elementy** — `igsn` a ostatní ve vzoru zakomentované elementy jsou při importu ignorovány i když jsou v XML přítomny; IGSN se přiděluje automaticky po archivaci.
- **Existující nálezce** — při `nalezce id=":tba"` se nejprve vyhledá osoba se shodným jménem a příjmením v DB; nová osoba se vytvoří pouze pokud neexistuje. Dříve aplikace vracela chybu.
- **Oprávnění pro vytvoření osoby** — odstraněna podmínka vyžadující oprávnění `model_edit` při vytváření nové osoby z importu; vytvoření se řídí standardními oprávněními pro import nálezu.

### XSD validace
- Import validuje dokument oproti skutečnému XSD ze zadané URL (stahováno a cachováno v Redisu). Odstraněno přesměrování na lokální soubor a pomocná metoda `_build_schema_validation_doc`.
- Implementován whitelist podporovaných verzí XSD přes `allowed_schema_versions` v `CustomAdminSettings`. Nepodporovaná verze vrátí HTTP 422.

### Překlady
- Opraveno chybějící generování překladového řetězce `pas.api.SamostatnyNalezXmlImportView.import_history_note` — alias `_l` (`gettext_lazy as _l`) nahrazen přímým voláním `gettext_lazy(...)`, které `makemessages` extrahuje automaticky.

### Logování
- Chyby v importovaných datech (`ImportValidationException`, `IntegrityError`) jsou logovány jako `WARNING`; `ERROR` zůstává pouze pro skutečně neočekávané stavy (Fedora, databáze, neošetřené výjimky).

### Dokumentace
- Aktualizována RST dokumentace importního endpointu (`pas_api.rst`) — upřesněno chování `amcr:stav` (hodnota z XML použita jako cílový stav), geometrie, ignorovaných elementů a atributu `lang`.
- Aktualizována RST dokumentace modulu (`pas/api.rst`) — přidány nové metody, odstraněny zrušené.

### Admin
- `ApiRequestLogAdmin` převeden na dekorátor `@admin.register`.