### PR TITLE
Úprava logiky pro zadání IGSN #3017

### DIFF
--- a/docker-compose-dev-local-db-all-containers.yml
+++ b/docker-compose-dev-local-db-all-containers.yml
@@ -97,7 +97,7 @@ services:
 
   redis:
     build: ./redis
-    image: redis:8.6.2
+    image: redis:8.6.3
     ports:
       - "6379:6379"
     secrets:
@@ -105,7 +105,7 @@ services:
     command: sh -c 'redis-server /home/redis/redis.conf'
 
   redis-exporter:
-    image: oliver006/redis_exporter:v1.82.0-alpine
+    image: oliver006/redis_exporter:v1.83.0-alpine
     ports:
       - "9121:9121"
     secrets:
@@ -200,7 +200,7 @@ services:
     shm_size: '2gb'
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:9.3.3
+    image: docker.elastic.co/logstash/logstash:9.4.1
     depends_on:
       - elasticsearch
     ports:
@@ -211,7 +211,7 @@ services:
       - ./logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.4.1
     environment:
       - discovery.type=single-node
       - http.host=0.0.0.0
@@ -223,7 +223,7 @@ services:
       - elasticsearch_volume:/usr/share/elasticsearch/data
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:9.3.3
+    image: docker.elastic.co/kibana/kibana:9.4.1
     restart: always
     ports:
       - 5601:5601

--- a/docker-compose-dev-local-db.yml
+++ b/docker-compose-dev-local-db.yml
@@ -77,7 +77,7 @@ services:
 
   redis:
     build: ./redis
-    image: redis:8.6.2
+    image: redis:8.6.3
     ports:
       - "6379:6379"
     secrets:

--- a/docs/source/04_django_aplikace/04_02_moduly/pid/views.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pid/views.rst
@@ -100,9 +100,11 @@ Třídy
       Vyhledá DOI v CrossRef API pomocí přímého DOI.
 
       U objektu ``message`` (jedna práce i položky ve výsledném seznamu) se předpokládá vždy pole ``DOI``.
+      Záložní vyhledávání podle názvu se záměrně neprovádí — DOI jako dotaz pro ``query.title``
+      vrací nesouvisející výsledky z CrossRef a blokuje dotaz na DataCite.
 
       :param q: Vyhledávací dotaz (DOI).
-      :return: Seznam [DOI, název] párů.
+      :return: Seznam [DOI, název] párů, nebo prázdný seznam pokud DOI v CrossRef neexistuje.
 
    .. py:method:: _doi_item_exists()
 

--- a/docs/source/12_zavislosti/docker_images.rst
+++ b/docs/source/12_zavislosti/docker_images.rst
@@ -58,7 +58,7 @@ Tyto image jsou standardní open-source image používané pro provoz podpůrný
 redis
 ~~~~~
 
-- **Verze:** 8.6.2
+- **Verze:** 8.6.3
 - **Licence:** RSALv2, SSPLv1
 - **Odkaz:** https://github.com/redis/redis
 
@@ -94,7 +94,7 @@ Image pro synchronizaci souborů pomocí rsync. Používá se pro zálohování 
 oliver006/redis_exporter
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Verze:** v1.82.0-alpine
+- **Verze:** v1.83.0-alpine
 - **Licence:** MIT license
 - **Odkaz:** https://github.com/oliver006/redis_exporter
 
@@ -130,7 +130,7 @@ Prometheus pro sběr a ukládání metrik. Slouží jako centrální systém pro
 docker.elastic.co/logstash/logstash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Verze:** 9.3.3
+- **Verze:** 9.4.1
 - **Licence:** SSPL, Elastic License 2.0, Apache License 2.0
 - **Odkaz:** https://github.com/elastic/logstash
 
@@ -139,7 +139,7 @@ Logstash pro zpracování a transformaci logů. Zajišťuje parsování a indexo
 docker.elastic.co/elasticsearch/elasticsearch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Verze:** 9.3.3
+- **Verze:** 9.4.1
 - **Licence:** SSPL, Elastic License 2.0, Apache License 2.0
 - **Odkaz:** https://github.com/elastic/elasticsearch
 
@@ -148,7 +148,7 @@ Elasticsearch pro fulltextové vyhledávání a analýzu logů. Ukládá a index
 docker.elastic.co/kibana/kibana
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Verze:** 9.3.3
+- **Verze:** 9.4.1
 - **Licence:** SSPL, Elastic License 2.0, Apache License 2.0
 - **Odkaz:** https://github.com/elastic/kibana
 

--- a/webclient/pid/views.py
+++ b/webclient/pid/views.py
@@ -3,7 +3,7 @@ import asyncio
 import concurrent.futures
 import re
 import unicodedata
-from urllib.parse import quote, quote_plus
+from urllib.parse import quote
 
 import httpx
 import requests
@@ -260,9 +260,11 @@ class DoiAutocompleteView(LoginRequiredMixin, ApiView):
         Vyhledá DOI v CrossRef API pomocí přímého DOI.
 
         U objektu ``message`` (jedna práce i položky ve výsledném seznamu) se předpokládá vždy pole ``DOI``.
+        Záložní vyhledávání podle názvu se záměrně neprovádí — DOI jako dotaz pro ``query.title``
+        vrací nesouvisející výsledky z CrossRef a blokuje dotaz na DataCite.
 
         :param q: Vyhledávací dotaz (DOI).
-        :return: Seznam [DOI, název] párů.
+        :return: Seznam [DOI, název] párů, nebo prázdný seznam pokud DOI v CrossRef neexistuje.
         """
         q = (q or "").strip()
         if not q:
@@ -272,8 +274,8 @@ class DoiAutocompleteView(LoginRequiredMixin, ApiView):
         try:
             response = requests.get(base_url, timeout=cls.HTTP_TIMEOUT)
         except requests.RequestException:
-            response = None
-        if response is not None and response.status_code == 200:
+            return []
+        if response.status_code == 200:
             try:
                 payload = response.json()
             except ValueError:
@@ -282,25 +284,6 @@ class DoiAutocompleteView(LoginRequiredMixin, ApiView):
             doi_id = msg.get("DOI")
             title = cls._crossref_item_display_title(msg) or doi_id
             return [[doi_id, f"{title} ({doi_id})"]]
-        else:
-            list_url = f"https://api.crossref.org/works?query.title={quote_plus(q)}&sort=relevance&rows=50"
-            try:
-                response = requests.get(list_url, timeout=cls.HTTP_TIMEOUT)
-            except requests.RequestException:
-                return []
-            results = []
-            if response.status_code == 200:
-                try:
-                    payload = response.json()
-                except ValueError:
-                    return []
-                for item in payload.get("message", {}).get("items", []):
-                    if not isinstance(item, dict):
-                        continue
-                    doi = item.get("DOI")
-                    label = cls._crossref_item_display_title(item) or doi
-                    results.append([doi, f"{label} ({doi})"])
-                return results
         return []
 
     @classmethod
@@ -378,13 +361,14 @@ class DoiAutocompleteView(LoginRequiredMixin, ApiView):
         else:
             results = []
         if not results:
+            is_doi = bool(cls.CROSSREF_DOI_REGEX.match(q))
 
             async def _fetch_all():
-                return await asyncio.gather(
-                    cls._api_call_data_cite_doi(q),
-                    cls._api_call_data_cite(q),
-                    cls._api_call_cross_ref_title(q),
-                )
+                tasks = [cls._api_call_data_cite_doi(q), cls._api_call_data_cite(q)]
+                if not is_doi:
+                    tasks.append(cls._api_call_cross_ref_title(q))
+                gathered = await asyncio.gather(*tasks)
+                return gathered[0], gathered[1], gathered[2] if not is_doi else []
 
             try:
                 loop = asyncio.get_running_loop()

--- a/webclient/pid/views.py
+++ b/webclient/pid/views.py
@@ -356,19 +356,22 @@ class DoiAutocompleteView(LoginRequiredMixin, ApiView):
         q = (q or "").strip()
         if not q:
             return []
-        if cls.CROSSREF_DOI_REGEX.match(q):
+        is_doi = bool(cls.CROSSREF_DOI_REGEX.match(q))
+        if is_doi:
             results = cls._api_call_cross_ref_doi(q)
         else:
             results = []
         if not results:
-            is_doi = bool(cls.CROSSREF_DOI_REGEX.match(q))
 
             async def _fetch_all():
                 tasks = [cls._api_call_data_cite_doi(q), cls._api_call_data_cite(q)]
                 if not is_doi:
                     tasks.append(cls._api_call_cross_ref_title(q))
                 gathered = await asyncio.gather(*tasks)
-                return gathered[0], gathered[1], gathered[2] if not is_doi else []
+                doi_results = gathered[0]
+                title_results = gathered[1]
+                crossref_results = gathered[2] if not is_doi else []
+                return doi_results, title_results, crossref_results
 
             try:
                 loop = asyncio.get_running_loop()
@@ -380,7 +383,7 @@ class DoiAutocompleteView(LoginRequiredMixin, ApiView):
             else:
                 doi_results, title_results, crossref_results = asyncio.run(_fetch_all())
             results = doi_results + title_results + crossref_results
-        if cls.CROSSREF_DOI_REGEX.match(q) and not any(
+        if is_doi and not any(
             i and len(i) > 0 and i[0] is not None and str(i[0]).lower() == q.lower() for i in results
         ):
             results = cls._doi_item_exists(q) + results


### PR DESCRIPTION
## Popis změn

### Oprava logiky automatického doplňování DOI (`pid/views.py`)

Opraveno chybné chování pole pro zadání externího zdroje (DOI), kdy zadání celého DOI ve tvaru `10.XXXXX/...` vracelo více nesouvisejících výsledků, zatímco zadání samotného suffixu (např. `C-N9000143`) vracelo správně jeden výsledek.

**Příčina:** Metoda `_api_call_cross_ref_doi` při neúspěšném přímém vyhledání v CrossRef padala zpět na vyhledávání podle názvu (`query.title`) s DOI řetězcem jako dotazem. CrossRef toto bral jako textový dotaz a vracel nesouvisející záznamy (např. papery obsahující číslo `71928` v metadatech). Navíc neprázdný výsledek tohoto fallbacku způsoboval přeskočení dotazu na DataCite, kde záznam AMČR skutečně sídlí.

**Řešení:**
- Odstraněn fallback na title search z `_api_call_cross_ref_doi` — při neúspěšném přímém vyhledání metoda vrátí prázdný seznam
- V `api_call` přidán příznak `is_doi` (vypočítán jednou z `CROSSREF_DOI_REGEX`) a při DOI dotazu přeskočeno volání `_api_call_cross_ref_title`, které by produkovalo stejný šum
- Zachována plná paralelizace async volání přes `asyncio.gather`
- Rozbalení výsledků `gathered` do pojmenovaných proměnných pro lepší čitelnost

### Aktualizace Docker image verzí

| Image | Stará verze | Nová verze |
|---|---|---|
| `redis` | 8.6.2 | 8.6.3 |
| `oliver006/redis_exporter` | v1.82.0-alpine | v1.83.0-alpine |
| `docker.elastic.co/logstash/logstash` | 9.3.3 | 9.4.1 |
| `docker.elastic.co/elasticsearch/elasticsearch` | 9.3.3 | 9.4.1 |
| `docker.elastic.co/kibana/kibana` | 9.3.3 | 9.4.1 |

## Test

- Zadat do pole DOI hodnotu `C-N9000143` → vrátí 1 výsledek (záznam AMČR)
- Zadat do pole DOI hodnotu `10.71928/C-N9000143` → vrátí 1 výsledek (stejný záznam AMČR)
- Zadat do pole DOI název publikace → vrátí výsledky z CrossRef i DataCite jako dříve

🤖 Generated with [Claude Code](https://claude.com/claude-code)