### PR TITLE
bug/3983

### DIFF
--- a/webclient/static/scss/_app-vypis.scss
+++ b/webclient/static/scss/_app-vypis.scss
@@ -20,6 +20,7 @@
       margin-bottom: 16px;
       background-color: #fff8e1;
       padding: 15px;
+      overflow-x: auto;
     }
 
     .section-name {
@@ -43,11 +44,15 @@
     .main-header {
       font-weight: bolder;
       font-size: 1.3rem;
+      overflow-wrap: anywhere;
+      word-break: break-word;
 
     }
 
     .sub-header {
       color: rgb(103, 103, 103);
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
     .label {
@@ -58,6 +63,25 @@
     .content {
       flex: 0 0 auto;
       max-width: 82%;
+    }
+
+    .vypis-field-row {
+      display: grid;
+      grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
+      column-gap: 0.5rem;
+      align-items: start;
+      margin-bottom: 0.125rem;
+
+      .label,
+      .content {
+        min-width: 0;
+        max-width: none;
+      }
+
+      .content {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
     }
 
     .thumb {
@@ -76,12 +100,43 @@
       .content {
         flex: 0 0 auto;
         max-width: 80%;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .vypis-field-row {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .label {
+        margin-bottom: 0.125rem;
+      }
+    }
+
+    @media print {
+      .record {
+        overflow-x: visible;
+      }
+
+      .vypis-field-row {
+        grid-template-columns: minmax(170px, 210px) minmax(0, 1fr);
       }
     }
 
     .small {
       font-size: 0.8rem;
       padding-left: 40px;
+    }
+
+    .vypis-history-list {
+      margin: 0.25rem 0 0.5rem;
+      padding-left: 1.25rem;
+
+      li {
+        margin-bottom: 0.125rem;
+      }
     }
   }
 }

--- a/webclient/static/scss/_app-vypis.scss
+++ b/webclient/static/scss/_app-vypis.scss
@@ -45,14 +45,12 @@
       font-weight: bolder;
       font-size: 1.3rem;
       overflow-wrap: anywhere;
-      word-break: break-word;
 
     }
 
     .sub-header {
       color: rgb(103, 103, 103);
       overflow-wrap: anywhere;
-      word-break: break-word;
     }
 
     .label {
@@ -80,7 +78,6 @@
 
       .content {
         overflow-wrap: anywhere;
-        word-break: break-word;
       }
     }
 
@@ -101,7 +98,13 @@
         flex: 0 0 auto;
         max-width: 80%;
         overflow-wrap: anywhere;
-        word-break: break-word;
+      }
+
+      .vypis-field-row {
+        .content {
+          flex: initial;
+          max-width: none;
+        }
       }
     }
 

--- a/webclient/vypis/templates/vypis/historie.html
+++ b/webclient/vypis/templates/vypis/historie.html
@@ -1,5 +1,7 @@
 <div>
-{% for historie_part in field.historie %}
-    <li><strong>{{ historie_part.datum_zmeny|date:'Y-m-d H:i' }}</strong> - {{historie_part.uzivatel_protected }} - {{ historie_part.get_typ_zmeny_display }}{%if historie_part.poznamka%}: {{historie_part.poznamka}}{% endif %}</li>
-{% endfor %}
+    <ul class="vypis-history-list">
+    {% for historie_part in field.historie %}
+        <li><strong>{{ historie_part.datum_zmeny|date:'Y-m-d H:i' }}</strong> - {{historie_part.uzivatel_protected }} - {{ historie_part.get_typ_zmeny_display }}{%if historie_part.poznamka%}: {{historie_part.poznamka}}{% endif %}</li>
+    {% endfor %}
+    </ul>
 </div>

--- a/webclient/vypis/templates/vypis/simple_section_with_name.html
+++ b/webclient/vypis/templates/vypis/simple_section_with_name.html
@@ -9,7 +9,7 @@
             {% elif field.template %}
                 {% include field.template with section=field %}
             {% elif section != "section_name" %}
-            <div class="row">
+            <div class="row vypis-field-row">
                 <div class="label"><strong>{{field.label}}:</strong></div>
                 <div class="content">{{ field.value }}</div>
             </div>

--- a/webclient/vypis/templates/vypis/simple_section_without_name.html
+++ b/webclient/vypis/templates/vypis/simple_section_without_name.html
@@ -1,7 +1,7 @@
 {% for section, field in section.items %}
         {% if section != "section_name" and section != "template" %}
         {% if field.value %}
-        <div class="row">
+        <div class="row vypis-field-row">
             <div class="label"><strong>{{field.label}}:</strong></div><div class="content"> {{ field.value }}</div>
         </div>
         {% endif %}

--- a/webclient/vypis/templates/vypis/soubory.html
+++ b/webclient/vypis/templates/vypis/soubory.html
@@ -4,25 +4,25 @@
             <div class="thumb"><a href="{{section.path.value.download}}" target="_blank"><img src="{{section.small_thumbnail.value}}" class="image-nahled" loading="lazy" style="opacity:0" onload="this.style.opacity=100"></a></div>
             <div class="file">
                 {% if section.path %}
-                <div class="row">
+                <div class="row vypis-field-row">
                     <div class="label"><strong>{{ section.path.label }}:</strong></div>
                     <div class="content"> {{ section.path.value.value }}</div>
                 </div>
                 {% endif %}
                 {% if section.rozsah %}
-                <div class="row">
+                <div class="row vypis-field-row">
                     <div class="label"><strong>{{ section.rozsah.label }}:</strong></div>
                     <div class="content"> {{ section.rozsah.value }}</div>
                 </div>
                 {% endif %}
                 {% if section.size_mb %}
-                <div class="row">
+                <div class="row vypis-field-row">
                     <div class="label"><strong>{{ section.size_mb.label }}:</strong></div>
                     <div class="content"> {{ section.size_mb.value }}</div>
                 </div>
                 {% endif %}
                 {% if section.sha_512 %}
-                <div class="row">
+                <div class="row vypis-field-row">
                     <div class="label"><strong>{{ section.sha_512.label }}:</strong></div>
                     <div class="content"> {{ section.sha_512.value }}</div>
                 </div>


### PR DESCRIPTION
#3983
- pridan fallback horizontalniho scrollu pro zaznamy vypisu
- zavedena trida vypis-field-row pro radkove responsivni zalamovani label/content
- doplneno zalamovani dlouhych hodnot v hlavicce a obsahu
- upraveny sablony simple_section a soubory pro novy radkovy layout
- opravena semantika historie: li polozky obaleny ul + scoped odsazeni seznamu