### PR TITLE
bug/3894

### DIFF
--- a/webclient/core/decorators.py
+++ b/webclient/core/decorators.py
@@ -84,10 +84,12 @@ def odstavka_in_progress(view_func):
                     return render(
                         request,
                         "/vol/web/nginx/data/" + language + "/oznameni/custom_503.html",
+                        status=503,
                     )
                 return render(
                     request,
                     "/vol/web/nginx/data/" + language + "/custom_503.html",
+                    status=503,
                 )
         return view_func(request, *args, **kwargs)
 

--- a/webclient/core/decorators.py
+++ b/webclient/core/decorators.py
@@ -7,6 +7,7 @@ from core.utils import get_set_maintenance_in_cache, is_maintenance_in_progress
 from django.shortcuts import render
 
 logger = logging.getLogger(__name__)
+MAINTENANCE_TEMPLATE_BASE_DIR = "/vol/web/nginx/data"
 
 
 def allowed_user_groups(allowed_groups):
@@ -83,12 +84,12 @@ def odstavka_in_progress(view_func):
                 if "oznameni" in request.path:
                     return render(
                         request,
-                        "/vol/web/nginx/data/" + language + "/oznameni/custom_503.html",
+                        f"{MAINTENANCE_TEMPLATE_BASE_DIR}/{language}/oznameni/custom_503.html",
                         status=503,
                     )
                 return render(
                     request,
-                    "/vol/web/nginx/data/" + language + "/custom_503.html",
+                    f"{MAINTENANCE_TEMPLATE_BASE_DIR}/{language}/custom_503.html",
                     status=503,
                 )
         return view_func(request, *args, **kwargs)


### PR DESCRIPTION
Vrácení HTTP 503 během odstávky

- explicitně nastaveno status=503 v maintenance větvi dekorátoru
- beze změny ostatního chování

Refs #3894
