### PR TITLE
Oprava zobrazení projektu ve spolupráci

### DIFF
--- a/docs/generate_module_docs.py
+++ b/docs/generate_module_docs.py
@@ -2299,7 +2299,7 @@ def _is_git_ignored(path: Path) -> bool:
     """
     try:
         result = subprocess.run(
-            ["git", "check-ignore", "-q", str(path)],
+            ["git", "check-ignore", "-q", path.name],
             cwd=path.parent,
             capture_output=True,
         )

--- a/docs/generate_module_docs.py
+++ b/docs/generate_module_docs.py
@@ -2285,6 +2285,30 @@ def _fetch_dockerhub_odkaz(image: str) -> str:
         return ""
 
 
+def _is_git_ignored(path: Path) -> bool:
+    """Zjistí, zda je soubor ignorovaný gitem (``.gitignore`` apod.).
+
+    Využívá ``git check-ignore``. Pokud git není dostupný nebo příkaz selže,
+    soubor se považuje za sledovaný (vrací ``False``), aby kontrola zůstala
+    konzervativní mimo git repozitář.
+
+    :param path: Cesta k souboru ke kontrole.
+    :type path: Path
+    :return: True, pokud je soubor ignorovaný gitem, jinak False.
+    :rtype: bool
+    """
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", str(path)],
+            cwd=path.parent,
+            capture_output=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    # Exit code 0 = ignorovaný, 1 = neignorovaný, 128 = mimo git repozitář.
+    return result.returncode == 0
+
+
 class DockerImageScanner:
     """Prohledává soubory projektu a sbírá tagy Docker image.
 
@@ -2392,7 +2416,7 @@ class DockerImageScanner:
         """
         priority_files = ["docker-compose.yml", "docker-compose-proxy.yml"]
 
-        all_compose = sorted(self.project_root.glob("docker-compose*.yml"))
+        all_compose = [f for f in sorted(self.project_root.glob("docker-compose*.yml")) if not _is_git_ignored(f)]
         ordered: List[Path] = []
 
         for name in priority_files:

--- a/docs/source/03_vyvoj/dokumentacni_skripty/generate_module_docs.rst
+++ b/docs/source/03_vyvoj/dokumentacni_skripty/generate_module_docs.rst
@@ -460,6 +460,19 @@ Funkce
    :return: Řetězec zdrojové URL, nebo prázdný řetězec při chybě nebo nepodporovaném registru.
    :rtype: str
 
+.. py:function:: _is_git_ignored(path)
+
+   Zjistí, zda je soubor ignorovaný gitem (``.gitignore`` apod.).
+
+   Využívá ``git check-ignore``. Pokud git není dostupný nebo příkaz selže,
+   soubor se považuje za sledovaný (vrací ``False``), aby kontrola zůstala
+   konzervativní mimo git repozitář.
+
+   :param path: Cesta k souboru ke kontrole.
+   :type path: Path
+   :return: True, pokud je soubor ignorovaný gitem, jinak False.
+   :rtype: bool
+
 .. py:function:: _parse_compose_versions(project_root)
 
    Parsuje všechny soubory docker-compose*.yml a Dockerfile-DB v project_root

--- a/docs/source/04_django_aplikace/04_02_moduly/projekt/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/projekt/models.rst
@@ -34,6 +34,8 @@ Třídy
 
       Vrací popisek projektu pro výběrová pole ve tvaru ``ident_cely (vedoucí projektu)``.
 
+      Pokud projekt nemá přiřazeného vedoucího, vrátí pouze ``ident_cely``.
+
       :return: Textový popisek projektu s vedoucím.
 
    .. py:method:: save()

--- a/docs/source/04_django_aplikace/04_02_moduly/projekt/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/projekt/models.rst
@@ -30,6 +30,12 @@ Třídy
 
       :return: Vrací hodnotu podle větve zpracování.
 
+   .. py:method:: popis_s_vedoucim()
+
+      Vrací popisek projektu pro výběrová pole ve tvaru ``ident_cely (vedoucí projektu)``.
+
+      :return: Textový popisek projektu s vedoucím.
+
    .. py:method:: save()
 
       Uloží změny objektu.

--- a/webclient/core/templates/core/transakce_table_modal.html
+++ b/webclient/core/templates/core/transakce_table_modal.html
@@ -138,7 +138,7 @@
     }
     else if (idTag === "edit-spoluprace-projekty-form") {
         base_url = '{% url "projekt:get_projekt_table_row" %}';
-        tag = $('#edit-spoluprace-projekty-form #id_projekty');
+        tag = $('#edit-spoluprace-projekty-form #id_edit-spoluprace-projekty-projekty');
         cl = '.edit-projekty-table';
     }
     else{

--- a/webclient/pas/filters.py
+++ b/webclient/pas/filters.py
@@ -438,10 +438,7 @@ class UzivatelSpolupraceFilter(HistorieFilter, filters.FilterSet):
                 stav__in=user.moje_stavy_pruzkumnych_projektu(),
             ).order_by("ident_cely")
         self.filters["projekty"].queryset = projekt_qs
-        self.filters["projekty"].field.label_from_instance = lambda obj: "%s (%s)" % (
-            obj.ident_cely,
-            obj.vedouci_projektu,
-        )
+        self.filters["projekty"].field.label_from_instance = Projekt.popis_s_vedoucim
         if user.hlavni_role.pk in (ROLE_ADMIN_ID, ROLE_ARCHIVAR_ID):
             self.filters["vedouci"] = ModelMultipleChoiceFilter(
                 queryset=User.objects.select_related("organizace"),

--- a/webclient/pas/forms.py
+++ b/webclient/pas/forms.py
@@ -67,7 +67,7 @@ class ProjectModelChoiceField(ModelChoiceField):
 
             :return: Vrací hodnotu podle větve zpracování.
         """
-        return "%s (%s)" % (obj.ident_cely, obj.vedouci_projektu)
+        return obj.popis_s_vedoucim()
 
 
 class PotvrditNalezForm(forms.ModelForm):
@@ -441,6 +441,7 @@ class EditSpolupraceProjektyForm(forms.ModelForm):
             qs = Projekt.objects.none()
         self.fields["projekty"].widget = AutocompleteSelect2Multiple()
         self.fields["projekty"].queryset = qs
+        self.fields["projekty"].label_from_instance = Projekt.popis_s_vedoucim
         self.fields["projekty"].required = False
         self.fields["projekty"].label = _("pas.forms.editSpolupraceProjekyForm.projekty.label")
         self.fields["projekty"].help_text = _("pas.forms.editSpolupraceProjekyForm.projekty.tooltip")

--- a/webclient/pas/views.py
+++ b/webclient/pas/views.py
@@ -1418,7 +1418,9 @@ class EditSpolupraceProjektyView(LoginRequiredMixin, TemplateView):
             :return: Vrací proměnná ``context``.
         """
         obj: UzivatelSpoluprace = self.get_object()
-        form = EditSpolupraceProjektyForm(instance=obj, vedouci_organizace=obj.vedouci.organizace)
+        form = EditSpolupraceProjektyForm(
+            instance=obj, vedouci_organizace=obj.vedouci.organizace, prefix="edit-spoluprace-projekty"
+        )
         return {
             "object": obj,
             "title": _("pas.views.editSpolupraceProjeky.title"),
@@ -1459,7 +1461,9 @@ class EditSpolupraceProjektyView(LoginRequiredMixin, TemplateView):
         if not check_permissions(p.actionChoices.spoluprace_edit_projekty, request.user, obj.id):
             messages.add_message(request, messages.ERROR, PRISTUP_ZAKAZAN)
             return JsonResponse({"redirect": reverse("pas:spoluprace_list")}, status=403)
-        form = EditSpolupraceProjektyForm(request.POST, instance=obj, vedouci_organizace=obj.vedouci.organizace)
+        form = EditSpolupraceProjektyForm(
+            request.POST, instance=obj, vedouci_organizace=obj.vedouci.organizace, prefix="edit-spoluprace-projekty"
+        )
         if form.is_valid():
             form.save()
             messages.add_message(request, messages.SUCCESS, _("pas.views.editSpolupraceProjeky.success"))

--- a/webclient/projekt/models.py
+++ b/webclient/projekt/models.py
@@ -219,9 +219,13 @@ class Projekt(ExportModelOperationsMixin("projekt"), ModelWithMetadata):
         """
         Vrací popisek projektu pro výběrová pole ve tvaru ``ident_cely (vedoucí projektu)``.
 
+        Pokud projekt nemá přiřazeného vedoucího, vrátí pouze ``ident_cely``.
+
         :return: Textový popisek projektu s vedoucím.
         """
-        return "%s (%s)" % (self.ident_cely, self.vedouci_projektu)
+        if self.vedouci_projektu:
+            return "%s (%s)" % (self.ident_cely, self.vedouci_projektu)
+        return self.ident_cely
 
     def save(self, *args, **kwargs):
         """

--- a/webclient/projekt/models.py
+++ b/webclient/projekt/models.py
@@ -215,6 +215,14 @@ class Projekt(ExportModelOperationsMixin("projekt"), ModelWithMetadata):
         if hasattr(self, "get_absolute_url") and hasattr(self, "ident_cely"):
             return f"<a href='{self.get_absolute_url()}' target='_blank' class='link-projekt'>{self.ident_cely}</a>"
 
+    def popis_s_vedoucim(self):
+        """
+        Vrací popisek projektu pro výběrová pole ve tvaru ``ident_cely (vedoucí projektu)``.
+
+        :return: Textový popisek projektu s vedoucím.
+        """
+        return "%s (%s)" % (self.ident_cely, self.vedouci_projektu)
+
     def save(self, *args, **kwargs):
         """
         Uloží změny objektu.


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix project display with leader in collaboration (spoluprace) forms
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

#2724
Oprava zobrazení Projektu s vedoucím.
Také jsem upravil precommit, aby nekontroloval soubory které jsou v git ignorované.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Adds <b><i>Projekt.popis_s_vedoucim()</i></b> model method to centralize the <b><i>ident_cely (vedouci_projektu)</i></b>
  label format, replacing duplicated inline lambdas in forms and filters.
• Fixes the <b><i>EditSpolupraceProjektyForm</i></b> by adding a <b><i>prefix=&quot;edit-spoluprace-projekty&quot;</i></b> to both GET
  and POST instantiations, and updates the JS selector in the modal template to match the prefixed
  field ID.
• Adds <b><i>_is_git_ignored()</i></b> helper to the docs script so that git-ignored <b><i>docker-compose*.yml</i></b> files
  (e.g. local overrides) are excluded from Docker image version scanning.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
    A["Projekt.popis_s_vedoucim()"] --> B["ProjectModelChoiceField"]
    A --> C["EditSpolupraceProjektyForm"]
    A --> D["UzivatelSpolupraceFilter"]
    C --> E["EditSpolupraceProjektyView"]
    E -- "prefix fix" --> F["transakce_table_modal.html"]
    G["_is_git_ignored()"] --> H["DockerImageScanner"]

    subgraph Legend
      direction LR
      _m["Model Method"] ~~~ _f["Form / Filter"] ~~~ _v["View / Template"]
    end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The PR&#x27;s approach is optimal. Extracting the label format into `Projekt.popis_s_vedoucim()` is the correct DRY refactor — it places the formatting logic on the model where it belongs, and all consumers (forms, filters) reference it uniformly. The form prefix fix is the correct Django idiom for disambiguating field IDs in multi-form pages. No meaningful alternatives were identified.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>generate_module_docs.py</strong> <code>Add &#x27;_is_git_ignored()&#x27; helper and filter git-ignored compose files</code> <code>+25/-1</code></summary>

<br/>

>Add &#x27;_is_git_ignored()&#x27; helper and filter git-ignored compose files
>
><pre>
>• Introduces &#x27;_is_git_ignored(path)&#x27; which uses &#x27;git check-ignore&#x27; to detect git-ignored files. &#x27;DockerImageScanner._ordered_compose_files()&#x27; now filters out git-ignored &#x27;docker-compose*.yml&#x27; files so local override files don&#x27;t pollute the version scan.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-78139b984a68d93eabd4b5e3225c79f17a1dd1d9545956e0d3009c005b33bc91'>docs/generate_module_docs.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>forms.py</strong> <code>Use &#x27;Projekt.popis_s_vedoucim&#x27; in forms and add form prefix</code> <code>+2/-1</code></summary>

<br/>

>Use &#x27;Projekt.popis_s_vedoucim&#x27; in forms and add form prefix
>
><pre>
>• Replaces the inline lambda in &#x27;ProjectModelChoiceField.label_from_instance&#x27; with a call to &#x27;Projekt.popis_s_vedoucim&#x27;. Also sets &#x27;label_from_instance&#x27; on the &#x27;projekty&#x27; field in &#x27;EditSpolupraceProjektyForm&#x27; and adds the &#x27;prefix=&#x27;edit-spoluprace-projekty&#x27;&#x27; kwarg to fix field ID generation.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-1f40cf7fb42e52281db7043c5e79ed8f4cf7c45d156dddc40e13f63a83262178'>webclient/pas/forms.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>views.py</strong> <code>Add form prefix to EditSpolupraceProjektyForm instantiation in view</code> <code>+6/-2</code></summary>

<br/>

>Add form prefix to EditSpolupraceProjektyForm instantiation in view
>
><pre>
>• Passes &#x27;prefix=&#x27;edit-spoluprace-projekty&#x27;&#x27; when constructing &#x27;EditSpolupraceProjektyForm&#x27; in both &#x27;get_context_data&#x27; and &#x27;post&#x27; handlers, ensuring HTML field IDs are prefixed and match the updated JS selector.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-bc2e081966ce0e06f7d19589c98494378466af22133aeab81da3a6da1e625389'>webclient/pas/views.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>transakce_table_modal.html</strong> <code>Fix JS selector to use prefixed field ID for spoluprace projekty form</code> <code>+1/-1</code></summary>

<br/>

>Fix JS selector to use prefixed field ID for spoluprace projekty form
>
><pre>
>• Updates the jQuery selector from &#x27;#id_projekty&#x27; to &#x27;#id_edit-spoluprace-projekty-projekty&#x27; to match the new Django form prefix, fixing the broken autocomplete table sync in the modal.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-da89c0813883b5a3077d610c3ea5e6813947833e20f3eb933067f5f54c0e6612'>webclient/core/templates/core/transakce_table_modal.html</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>models.py</strong> <code>Add &#x27;popis_s_vedoucim()&#x27; method to Projekt model</code> <code>+8/-0</code></summary>

<br/>

>Add &#x27;popis_s_vedoucim()&#x27; method to Projekt model
>
><pre>
>• Introduces a new instance method &#x27;popis_s_vedoucim()&#x27; on the &#x27;Projekt&#x27; model that returns a formatted string &#x27;ident_cely (vedouci_projektu)&#x27;. This centralises the label format previously duplicated as inline lambdas in forms and filters.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-aae2a26403cd4c65a3d143537062368b01686f9e8d88030aa677e2dfa465bdd6'>webclient/projekt/models.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>filters.py</strong> <code>Replace inline lambda with &#x27;Projekt.popis_s_vedoucim&#x27; in filter</code> <code>+1/-4</code></summary>

<br/>

>Replace inline lambda with &#x27;Projekt.popis_s_vedoucim&#x27; in filter
>
><pre>
>• Replaces the three-line inline lambda for &#x27;label_from_instance&#x27; in &#x27;UzivatelSpolupraceFilter&#x27; with a direct reference to &#x27;Projekt.popis_s_vedoucim&#x27;, eliminating duplication.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-16e81534b0dbbbcca0d9e80f11de17452aa0d9f7342bd8fbc78f4e03d974fa29'>webclient/pas/filters.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>generate_module_docs.rst</strong> <code>Document new &#x27;_is_git_ignored()&#x27; function in RST docs</code> <code>+13/-0</code></summary>

<br/>

>Document new &#x27;_is_git_ignored()&#x27; function in RST docs
>
><pre>
>• Adds a &#x27;.. py:function::&#x27; directive for &#x27;_is_git_ignored&#x27; to the Sphinx RST documentation, including parameter and return type descriptions.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-848b9b783050443870387b85129e6ed85220a827b931e4d1bf2acf86e40590c0'>docs/source/03_vyvoj/dokumentacni_skripty/generate_module_docs.rst</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>models.rst</strong> <code>Document new &#x27;popis_s_vedoucim()&#x27; method in Projekt model RST docs</code> <code>+6/-0</code></summary>

<br/>

>Document new &#x27;popis_s_vedoucim()&#x27; method in Projekt model RST docs
>
><pre>
>• Adds a &#x27;.. py:method::&#x27; directive for &#x27;popis_s_vedoucim()&#x27; to the Sphinx RST documentation for the Projekt model.
></pre>
>
><a href='https://github.com/ARUP-CAS/aiscr-webamcr/pull/4043/files#diff-d1a3ac8377d2b7d2b5f96d63b481c0b1b96693b5b07ca3cd41683ff5729fbd33'>docs/source/04_django_aplikace/04_02_moduly/projekt/models.rst</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>