### PR TITLE
Zlepšení nastavení redis cache

### DIFF
--- a/docs/source/04_django_aplikace/04_02_moduly/core/views.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/core/views.rst
@@ -445,6 +445,17 @@ Třídy
 
       :return: Vrací proměnná ``context``.
 
+   .. py:method:: _is_query_cacheable()
+
+      Vrací, zda je bezpečné zapnout cacheops cache pro aktuální filtr.
+
+      Spočítá součin počtů hodnot u vícehodnotových GET parametrů. Tento součin
+      odpovídá řádové velikosti invalidační DNF, kterou cacheops staví – u velkých
+      kombinací hlubokých M2M filtrů by její sestavení vyčerpalo paměť a shodilo
+      worker. Stránkovací a řadicí parametry se do součinu nezapočítávají.
+
+      :return: ``True`` pokud součin nepřekročí ``cache_filter_value_product_limit``.
+
    .. py:method:: get_queryset()
 
       Vrací queryset výsledků vyhledávání podle zadaných filtrů.

--- a/webclient/core/views.py
+++ b/webclient/core/views.py
@@ -1783,6 +1783,36 @@ class SearchListView(ExportMixin, LoginRequiredMixin, SingleTableMixin, FilterVi
         context["vypis_app"] = self.vypis_app
         return context
 
+    #: Limit pro zapnutí cacheops cache. cacheops sestavuje invalidační schéma (DNF)
+    #: jako kartézský součin hodnot napříč vícehodnotovými filtry. U hlubokých M2M
+    #: filtrů (předměty/objekty komponent) vede velký počet zvolených hodnot k milionům
+    #: konjunkcí a vyčerpání paměti (OOM) při výpočtu ``cacheops.tree.dnfs``. Pro
+    #: kombinace, jejichž součin počtů hodnot překročí tento limit, se cache vypíná.
+    cache_filter_value_product_limit = 1000
+
+    def _is_query_cacheable(self):
+        """
+        Vrací, zda je bezpečné zapnout cacheops cache pro aktuální filtr.
+
+        Spočítá součin počtů hodnot u vícehodnotových GET parametrů. Tento součin
+        odpovídá řádové velikosti invalidační DNF, kterou cacheops staví – u velkých
+        kombinací hlubokých M2M filtrů by její sestavení vyčerpalo paměť a shodilo
+        worker. Stránkovací a řadicí parametry se do součinu nezapočítávají.
+
+        :return: ``True`` pokud součin nepřekročí ``cache_filter_value_product_limit``.
+        """
+        ignored = {"page", "sort", "per_page", "csrfmiddlewaretoken"}
+        product = 1
+        for key in self.request.GET:
+            if key in ignored:
+                continue
+            count = len(self.request.GET.getlist(key))
+            if count > 1:
+                product *= count
+                if product > self.cache_filter_value_product_limit:
+                    return False
+        return True
+
     def get_queryset(self):
         """
         Vrací queryset výsledků vyhledávání podle zadaných filtrů.
@@ -1790,7 +1820,8 @@ class SearchListView(ExportMixin, LoginRequiredMixin, SingleTableMixin, FilterVi
         :return: Vrací proměnná ``qs``.
         """
         qs = super().get_queryset()
-        qs.cache()
+        if self._is_query_cacheable():
+            qs.cache()
         return qs
 
     @method_decorator(never_cache)

--- a/webclient/webclient/settings/base.py
+++ b/webclient/webclient/settings/base.py
@@ -106,7 +106,17 @@ def get_redis_pass(default_value=""):
 REDIS_HOST = get_secret("REDIS_HOST", "redis")
 REDIS_PORT = get_secret("REDIS_PORT", 6379)
 
-CACHEOPS_REDIS = f"redis://{get_redis_pass()}{REDIS_HOST}:{REDIS_PORT}/2"
+CACHEOPS_REDIS = {
+    "host": REDIS_HOST,
+    "port": int(REDIS_PORT),
+    "db": 2,
+    "password": get_plain_redis_pass(),
+    "socket_keepalive": True,
+    "health_check_interval": 30,
+    "retry_on_timeout": True,
+}
+
+CACHEOPS_DEGRADE_ON_FAILURE = True
 
 CACHEOPS = {
     "lokalita.Lokalita": {"ops": (), "timeout": 60 * 10},


### PR DESCRIPTION
#4093 
Optimalizace nastavení CACHEOPS_REDIS 
V případě problémů s komunikací s redis request doběhne bez cache jen s varováním. Týká se cache dotazů do databáze u výpisů.