### PR TITLE
Refactor entity color mixins to accept parameters for improved flexibility

### DIFF
--- a/webclient/static/scss/_app-mixins.scss
+++ b/webclient/static/scss/_app-mixins.scss
@@ -19,14 +19,19 @@
 }
 
 // set entity color
-@mixin setEntityColor($type) {
-  @each $entity, $color in $entities {
+// $entity-map: light ($entities) or dark ($dark-entities) entity color map
+// $card-footer-bg: footer background; pass null to leave background unset (dark theme)
+@mixin setEntityColor($type, $entity-map: $entities, $card-footer-bg: $white) {
+  @each $entity, $color in $entity-map {
     @if ($type ==card) {
       &.app-entity-#{$entity} {
         background-color: $color;
 
         .card-footer {
-          background-color: $white;
+          @if $card-footer-bg != null {
+            background-color: $card-footer-bg;
+          }
+
           color: $color;
         }
       }
@@ -35,8 +40,9 @@
 }
 
 // set entity color for all defined elements inside
-@mixin setEntityElementsColor() {
-  @each $entity, $color in $entities {
+// $entity-map: light ($entities) or dark ($dark-entities) entity color map
+@mixin setEntityElementsColor($entity-map: $entities) {
+  @each $entity, $color in $entity-map {
     .app-entity-#{$entity} {
 
       // common
@@ -135,7 +141,7 @@
         background-color: $color;
 
         &:hover {
-          $link-hover-color: darken($color, 10);
+          $link-hover-color: darken($color, 10%);
           border-color: $link-hover-color;
           background-color: $link-hover-color;
         }
@@ -282,8 +288,9 @@
 }
 
 // set entity color for all transakce table idents
-@mixin setEntityTransakceColor() {
-  @each $entity, $color in $entities {
+// $entity-map: light ($entities) or dark ($dark-entities) entity color map
+@mixin setEntityTransakceColor($entity-map: $entities) {
+  @each $entity, $color in $entity-map {
     .app-card-#{$entity} {
       table {
         tr {

--- a/webclient/static/scss/_app-theme-dark.scss
+++ b/webclient/static/scss/_app-theme-dark.scss
@@ -1,270 +1,8 @@
 // --- DARK THEME ---
 // Apply dark mode styles when data-theme="dark" is set
+// Entity colors reuse shared mixins from app-mixins with $dark-entities.
 
 @import 'app-variables-dark';
-
-
-// set entity color
-@mixin setEntityColor($type) {
-    @each $entity, $color in $dark-entities {
-        @if ($type ==card) {
-            &.app-entity-#{$entity} {
-                background-color: $color;
-
-                .card-footer {
-                    color: $color;
-                }
-            }
-        }
-    }
-}
-
-// set entity color for all defined elements inside
-@mixin setEntityElementsColor() {
-    @each $entity, $color in $dark-entities {
-        .app-entity-#{$entity} {
-
-            // common
-            .app-entity-color {
-                color: $color;
-            }
-
-            // toolbar
-            .app-toolbar {
-
-                .app-left {
-                    .app-entity-title {
-                        background-color: $color;
-
-                        &:after {
-                            background-color: $color;
-                        }
-                    }
-
-                    .app-entity-item {
-                        color: $color;
-
-                        button span.material-icons {
-                            color: $color;
-                        }
-
-                    }
-                }
-
-                .app-right {
-                    .btn {
-                        color: $color;
-                        border-left-color: rgba($color, .3) !important;
-
-                        &:hover {
-                            background-color: $color;
-                            color: $white;
-                        }
-                    }
-                }
-            }
-
-            // stepper
-            .bs-stepper {
-                overflow-x: auto;
-
-                .step {
-                    &.active {
-                        .bs-stepper-circle {
-                            background-color: $gray-100;
-                            color: $color;
-                            font-weight: bold;
-                            box-shadow: inset 0 0 0 5.4px $color;
-                        }
-
-                        .bs-stepper-label {
-                            color: $color;
-                        }
-                    }
-                }
-            }
-
-            // card header button
-            .card {
-                &.app-card-form {
-                    .card-header {
-                        background-color: rgba($color, 1.0);
-                        color: #fff;
-
-                        .btn-group {
-                            .btn {
-                                &:hover {
-                                    background-color: $color !important;
-                                    color: $white;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // entity card
-            .app-card-entity {
-                background-color: $color;
-
-                .card-footer {
-                    background-color: $white;
-                    color: $color;
-                }
-            }
-
-            // button color
-            .btn-primary {
-                border-color: $color;
-                background-color: $color;
-
-                &:hover {
-                    $link-hover-color: darken($color, 10%);
-                    border-color: $link-hover-color;
-                    background-color: $link-hover-color;
-                }
-            }
-
-            // check box color
-            .custom-control-input:checked~.custom-control-label::before {
-                border-color: $color;
-                background-color: $color;
-            }
-
-            .form-check-input:checked {
-                background-color: $color;
-                border-color: $color;
-            }
-
-            .badge {
-                background-color: $color !important;
-                color: $white;
-            }
-
-            // table list
-            .app-table-list-wrapper {
-                .table {
-                    thead {
-                        position: sticky;
-                        top: 0;
-                        --bs-table-bg: #{$color} !important;
-
-                        a {
-                            color: $white;
-                        }
-
-                        .white {
-                            color: $white;
-                        }
-                    }
-
-                    tbody {
-                        a {
-                            color: $color;
-                        }
-
-                        button {
-                            color: $color;
-                        }
-
-                        td {
-                            vertical-align: middle;
-                        }
-                    }
-                }
-            }
-
-            // pagination
-            .pagination {
-                .page-item {
-                    &.active {
-                        .page-link {
-                            background-color: $color;
-                            border: $color;
-                            color: $white;
-                            display: flex;
-                            border: 1px solid #dee2e6;
-                        }
-                    }
-
-                    .page-link {
-                        color: $color;
-                        display: flex;
-                    }
-                }
-            }
-
-            // dropdown
-            .dropdown-menu {
-                .dropdown-item {
-                    &:active {
-                        background-color: $color;
-                    }
-                }
-            }
-        }
-
-        // card behavior based on entity
-        .app-card-#{$entity} {
-            table {
-                tr {
-                    td {
-                        &.app-ident-cely {
-                            color: $color !important;
-
-                            .material-icons {
-                                color: $color;
-                            }
-
-                            a {
-                                color: $color;
-                            }
-                        }
-
-                        &.app-cell-badge {
-                            padding-left: 0;
-                        }
-
-                        .badge {
-                            background-color: $color !important;
-                            color: $white;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-// set entity color for all transakce table idents
-@mixin setEntityTransakceColor() {
-    @each $entity, $color in $dark-entities {
-        .app-card-#{$entity} {
-            table {
-                tr {
-                    td {
-                        &.app-ident-cely {
-                            color: $color !important;
-
-                            .material-icons {
-                                color: $color;
-                            }
-
-                            a {
-                                color: $color;
-                            }
-                        }
-
-                        .badge {
-                            background-color: $color !important;
-                            color: $white;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
 
 // Apply dark theme styles to the entire app when theme is set to dark
 html[data-theme="dark"],
@@ -285,13 +23,13 @@ body.app-dark-theme {
     color: $body-text-dark;
     background-color: $body-bg-dark;
 
-    @include setEntityTransakceColor();
+    @include setEntityTransakceColor($dark-entities);
 
     .app-entity-cards {
         .col {
 
             .app-card-entity {
-                @include setEntityColor("card");
+                @include setEntityColor("card", $dark-entities, null);
             }
         }
     }
@@ -369,7 +107,7 @@ body.app-dark-theme {
     }
 
     #app-page-wrapper .container-fluid.app-content-wrapper {
-        @include setEntityElementsColor();
+        @include setEntityElementsColor($dark-entities);
         background-color: $body-bg-dark;
 
         .app-toolbar {


### PR DESCRIPTION
## Summary

Follow-up to [#4132](https://github.com/ARUP-CAS/aiscr-webamcr/pull/4132) (dark-theme entity colors). Removes the duplicated entity-color mixins from `_app-theme-dark.scss` and extends the shared mixins in `_app-mixins.scss` so light and dark themes use one implementation.

- Parameterize `setEntityColor`, `setEntityElementsColor`, and `setEntityTransakceColor` with `$entity-map` (default `$entities`)
- Dark theme calls the shared mixins with `$dark-entities` instead of redefining the same mixins under the same names
- Preserve intentional dark behavior: entity card footers omit `background-color` via `@include setEntityColor(card, $dark-entities, null)`
- Align `darken($color, 10%)` in the shared mixin (Sass percentage unit)

## Why

The dark theme had ~250 lines of near-copies of the light mixins. That caused mixin-name collisions (safe only because dark is imported last) and high drift risk when light styles change.

## Test plan

- [ ] Compile SCSS / load app with light theme — entity colors unchanged for all entity types
- [ ] Dark theme — `akce` / `lokalita` / `samostatny_nalez` still use `$dark-entities` accents
- [ ] Dark theme — entity card footers still have no forced white background (intentional)
- [ ] Dark theme — toolbar still uses `$app-toolbar-bg-dark` (overrides shared tint via `!important`)
- [ ] Smoke transakce tables and entity list headers in dark mode for the three mapped entities

## Out of scope

- Completing `$dark-entities` for remaining entity types (still tracked against #4132 / #2322)
- Leaflet selector changes (intentionally not included)