### PR TITLE
bug/3983

### DIFF
--- a/webclient/static/js/html-to-rtf-browser.js
+++ b/webclient/static/js/html-to-rtf-browser.js
@@ -8946,6 +8946,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (attributes.class && attributes.class.includes('soubor')) {
                         tagName = tagName + '.soubor';
                     }
+                    if (attributes.class && attributes.class.includes('dok_zaznam') && attributes.class.includes('content')) {
+                        tagName = tagName + '.dok_zaznam';
+                    }
                     allowedTag = this.getAllowedTag(tagName);
 
                     if (allowedTag) {
@@ -9004,6 +9007,12 @@ document.addEventListener('DOMContentLoaded', function () {
                     opening: 'div',
                     openingRtf: '',
                     closing: '/div',
+                    closingRtf: ''
+                },
+                {
+                    opening: 'div.dok_zaznam',
+                    openingRtf: '\\\'20',
+                    closing: '/div.dok_zaznam',
                     closingRtf: ''
                 },
                 {
@@ -9242,9 +9251,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 },
                 {
                     opening: 'div.sub-header',
-                    openingRtf: '{\\pard{\\b',
+                    openingRtf: '{\\pard',
                     closing: '/div.sub-header',
-                    closingRtf: '}\\sb70\\par}'
+                    closingRtf: '\\sb70\\par}'
                 },
             ];
 

--- a/webclient/static/js/vypis-report.js
+++ b/webclient/static/js/vypis-report.js
@@ -17,6 +17,7 @@
 
         label.textContent = simpleViewEnabled ? fullLabel : simpleLabel;
         toggle.setAttribute('aria-label', simpleViewEnabled ? fullLabel : simpleLabel);
+        toggle.setAttribute('data-bs-original-title', simpleViewEnabled ? fullLabel : simpleLabel);
         toggle.checked = simpleViewEnabled;
 
         document.querySelectorAll('#app-wrapper .not-simple').forEach((section) => {

--- a/webclient/static/scss/_app-vypis.scss
+++ b/webclient/static/scss/_app-vypis.scss
@@ -15,7 +15,6 @@
       white-space: normal;
       word-break: normal;
       overflow-wrap: break-word;
-      /* only if needed as fallback */
     }
 
     @media (max-width: 649.98px) {

--- a/webclient/static/scss/_app-vypis.scss
+++ b/webclient/static/scss/_app-vypis.scss
@@ -12,7 +12,16 @@
   .app-content-wrapper {
 
     .simple-view-label {
-      word-break: break-word;
+      white-space: normal;
+      word-break: normal;
+      overflow-wrap: break-word;
+      /* only if needed as fallback */
+    }
+
+    @media (max-width: 649.98px) {
+      .simple-view-label {
+        display: none;
+      }
     }
 
     button {

--- a/webclient/vypis/config.py
+++ b/webclient/vypis/config.py
@@ -369,7 +369,7 @@ DOKUMENTY_CONFIG = {
             ),
             "template": SimpleSectionTemplateName("vypis/simple_section_with_name.html"),
             "dok_zaznam": ChooseField(
-                _("vypis.dokumenty.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"]
+                _("vypis.dokumenty.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"], "dok_zaznam"
             ),
             "komponenty": SubSectionField(KOMPONENTY_DOKU_CONFIG),
             "neident_akce": NeidentAkceSubSectionField(NEIDENT_AKCE_CONFIG),
@@ -921,7 +921,7 @@ MODEL_CONFIG = {
             ),
             "template": SimpleSectionTemplateName("vypis/simple_section_with_name.html"),
             "dok_zaznam": ChooseField(
-                _("vypis.model3d.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"]
+                _("vypis.model3d.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"], "dok_zaznam"
             ),
             "komponenty": SubSectionField(KOMPONENTY_DOKU_CONFIG),
         },

--- a/webclient/vypis/fields.py
+++ b/webclient/vypis/fields.py
@@ -993,7 +993,7 @@ class KomponentaRepeatableSectionNameWithAccessor(RepeatableSectionNameWithAcces
         if aktivity:
             third_part = f" ({'; '.join([str(a) for a in aktivity])})"
         return format_html(
-            "<span class='ps-0'>{} {} - {}{} - {}{}</span>",
+            "<span class='ps-0'>{}&nbsp;{}&nbsp;-&nbsp;{}{}&nbsp;-&nbsp;{}{}</span>",
             self.name,
             getattr(instance, self.accessor[0]),
             obdobi,

--- a/webclient/vypis/templates/vypis/simple_section_with_name.html
+++ b/webclient/vypis/templates/vypis/simple_section_with_name.html
@@ -13,7 +13,7 @@
             {% elif section != "section_name" %}
                 <div class="row vypis-field-row {{ field.css_class }}">
                 <div class="label"><strong>{{field.label}}:</strong></div>
-                <div class="content">{{ field.value }}</div>
+                <div class="content {{ field.css_class }}">{{ field.value }}</div>
             </div>
             {% endif %}
         </div>

--- a/webclient/vypis/templates/vypis/vypis.html
+++ b/webclient/vypis/templates/vypis/vypis.html
@@ -25,16 +25,21 @@
   {% endif %}
 <div>
     <div class="row" id="title_row">
-        <div class="col-8">
+        <div class="col-7">
             <h1>{{title}}</h1>
         </div>
-        <div class="col-4 d-print-none align-self-center no-export">
+        <div class="col-2"></div>
+        <div class="col-3 d-print-none align-self-center no-export">
             <div class="d-flex align-items-center justify-content-end gap-2">
                 <div class="form-check-reverse form-switch mb-0">
                     <input class="form-check-input" type="checkbox" id="simple-view-toggle" onchange="toggleSimpleView()"
                         aria-label="{% trans 'vypis.templates.vypis.simple_view.label' %}"
                         data-simple-label="{% trans 'vypis.templates.vypis.simple_view.label' %}"
-                        data-full-label="{% trans 'vypis.templates.vypis.full_view.label' %}">
+                        data-full-label="{% trans 'vypis.templates.vypis.full_view.label' %}"
+                        title="{% trans 'vypis.templates.vypis.simple_view.label' %}"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        data-bs-trigger="hover">
                     <label class="form-check-label simple-view-label" for="simple-view-toggle" id="simple-view-toggle-label">
                         {% trans 'vypis.templates.vypis.simple_view.label' %}
                     </label>
@@ -55,4 +60,15 @@
 </div>
 {% endblock %}
 
-{% block script %}{% endblock %}
+{% block script %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const tooltipTriggerList = [].slice.call(
+        document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    );
+    tooltipTriggerList.forEach(function (el) {
+        new bootstrap.Tooltip(el);
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
<!-- aiscr-review-pr:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4151

| Field | Value |
| --- | --- |
| Title | bug/3983 |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4151 |
| Author | @jnihnat |
| Base ← head | `test` ← `bug/3893` |
| Head SHA | `76f98e9c379edbc65d775350ecd09bf5d45e9500` |
| Size | +46 / −11 across 7 files |
| State | OPEN |
| Marked AIS CR review baseline | none |
| Prior PR summary | none |

## Purpose and scope

Addresses [#3983](https://github.com/ARUP-CAS/aiscr-webamcr/issues/3983) (výpisy responsivity / switch display) and related RTF export formatting for dokument-casti `dok_zaznam` fields and sub-headers. Scope is front-end vypis UI (layout, switch label/tooltip, SCSS) plus HTML→RTF tag mapping and small template/config hooks so `dok_zaznam` is recognizable in export.

## Change map by area

| Area | Files | What changed |
| --- | --- | --- |
| Switch / header layout | `vypis.html`, `_app-vypis.scss`, `vypis-report.js` | Narrower action column (`col-7` / spacer / `col-3`), wrap rules for the label, hide label under ~650px, Bootstrap tooltip on the toggle, sync `data-bs-original-title` on toggle |
| Field CSS hook for RTF | `config.py`, `simple_section_with_name.html` | Pass `css_class="dok_zaznam"` into two `ChooseField`s; echo class on the content `div` |
| RTF converter | `html-to-rtf-browser.js` | Recognize `div.dok_zaznam` (+ content), emit leading `\'20`; drop bold wrapper on `div.sub-header` |
| Komponenta title HTML | `fields.py` | Prefer `&nbsp;` around separators in section name markup |

## Change walkthrough

The switch cluster is given more horizontal room and a tooltip so the mode name can hide on narrow viewports while the checkbox remains usable. For RTF, dokument-casti linked záznam fields gain a `dok_zaznam` class on the content cell; the converter maps that class to a leading space in RTF and un-bolds sub-headers. Non-breaking spaces in komponenta titles reduce awkward wraps in the HTML report.

```mermaid
flowchart LR
  cfg["config ChooseField css_class"] --> tpl["content div.dok_zaznam"]
  tpl --> rtf["html-to-rtf tag map"]
  ui["vypis.html + SCSS switch"] --> tip["Bootstrap tooltip"]
  ui --> js["vypis-report.js title sync"]
```

## Attention hints (summary only)

- Head branch is named `bug/3893` while the PR title and issue link use `#3983`.
- Issue [#3983](https://github.com/ARUP-CAS/aiscr-webamcr/issues/3983) also discusses early whole-layout wrapping for A4 print; this diff focuses on the switch cluster and RTF, not a full print-breakpoint redesign.
- Empty `col-2` spacer is an unusual Bootstrap layout device; worth a quick visual check at mid widths.

## Validation / test surfaces visible in the PR

- Visible in the PR: GitHub Actions pre-commit bot comment reports hooks passed ([run 29614690975](https://github.com/ARUP-CAS/aiscr-webamcr/actions/runs/29614690975)).
- Not executed in this review session: browser/visual check of the switch at narrow widths, tooltip after toggle, or sample RTF export for dokument / model3d výpisy.

## Lineage

First AIS CR review round for this head SHA. No marked prior review, no marked summary surface, no open inline threads. Author description is the short Czech note linking `#3983`.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
