### PR TITLE
Úprava řazení náhledů

### DIFF
--- a/docs/source/04_django_aplikace/04_02_moduly/core/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/core/models.rst
@@ -326,6 +326,28 @@ Funkce
    :param filename: Název souboru.
    :return: Cesta pro uložení souboru.
 
+.. py:function:: soubor_nazev_razeni_klic(soubor)
+
+   Vrátí řadicí klíč souboru podle názvu.
+
+   Tečka je nahrazena znakem ``0``, aby se soubory řadily shodně s výpisem souborů
+   v detailu záznamu (např. ``nazev.jpg`` před ``nazev-2.jpg``). Používá se pro
+   jednotné určení pořadí souborů i výběr náhledového souboru napříč dokumenty,
+   3D modely i samostatnými nálezy.
+
+   :param soubor: Soubor, z jehož názvu se klíč sestaví.
+   :return: N-tice použitelná jako ``key`` pro ``sorted`` nebo ``min``.
+
+.. py:function:: prvni_soubor_dle_nazvu(soubory)
+
+   Vrátí náhledový soubor jako první soubor seřazený podle názvu.
+
+   Pořadí odpovídá výpisu souborů v detailu (viz :func:`soubor_nazev_razeni_klic`),
+   takže náhled je vždy první soubor v seznamu.
+
+   :param soubory: Iterovatelná kolekce souborů.
+   :return: Soubor s nejnižším řadicím klíčem názvu, nebo None pro prázdný vstup.
+
 .. py:function:: check_permissions(action, user, ident, skip_status)
 
    Ověří permissions. v aplikaci.

--- a/docs/source/04_django_aplikace/04_02_moduly/core/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/core/models.rst
@@ -330,10 +330,10 @@ Funkce
 
    Vrátí řadicí klíč souboru podle názvu.
 
-   Tečka je nahrazena znakem ``0``, aby se soubory řadily shodně s výpisem souborů
-   v detailu záznamu (např. ``nazev.jpg`` před ``nazev-2.jpg``). Používá se pro
-   jednotné určení pořadí souborů i výběr náhledového souboru napříč dokumenty,
-   3D modely i samostatnými nálezy.
+   Při porovnání se tečka chová jako znak ``0``, což zachovává dosavadní pořadí
+   výpisu souborů v detailu záznamu (např. ``foto.jpg`` před ``foto2.jpg``). Používá
+   se pro jednotné určení pořadí souborů i výběr náhledového souboru napříč
+   dokumenty, 3D modely i samostatnými nálezy.
 
    :param soubor: Soubor, z jehož názvu se klíč sestaví.
    :return: N-tice použitelná jako ``key`` pro ``sorted`` nebo ``min``.

--- a/docs/source/04_django_aplikace/04_02_moduly/dokument/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/dokument/models.rst
@@ -152,7 +152,7 @@ Třídy
 
    .. py:method:: thumbnail_image_file()
 
-      Vrací první soubor jako náhled (seřazeny abecedně).
+      Vrací první soubor jako náhled (seřazeno podle názvu shodně s výpisem souborů).
 
       :return: První seřazený soubor nebo None.
 

--- a/docs/source/04_django_aplikace/04_02_moduly/pas/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pas/models.rst
@@ -99,7 +99,7 @@ Třídy
 
    .. py:method:: nahled_soubor()
 
-      Vrací cestu k miniaturnímu náhledu souboru.
+      Vrací náhledový soubor (první podle názvu, shodně s výpisem souborů).
 
       :return: První soubor nebo None, pokud žádný neexistuje.
 

--- a/webclient/core/models.py
+++ b/webclient/core/models.py
@@ -125,6 +125,37 @@ class SouborVazby(ExportModelOperationsMixin("soubor_vazby"), models.Model):
             return self.samostatny_nalez_souboru
 
 
+def soubor_nazev_razeni_klic(soubor):
+    """
+    Vrátí řadicí klíč souboru podle názvu.
+
+    Tečka je nahrazena znakem ``0``, aby se soubory řadily shodně s výpisem souborů
+    v detailu záznamu (např. ``nazev.jpg`` před ``nazev-2.jpg``). Používá se pro
+    jednotné určení pořadí souborů i výběr náhledového souboru napříč dokumenty,
+    3D modely i samostatnými nálezy.
+
+    :param soubor: Soubor, z jehož názvu se klíč sestaví.
+    :return: N-tice použitelná jako ``key`` pro ``sorted`` nebo ``min``.
+    """
+    return (soubor.nazev.replace(".", "0"), soubor.nazev)
+
+
+def prvni_soubor_dle_nazvu(soubory):
+    """
+    Vrátí náhledový soubor jako první soubor seřazený podle názvu.
+
+    Pořadí odpovídá výpisu souborů v detailu (viz :func:`soubor_nazev_razeni_klic`),
+    takže náhled je vždy první soubor v seznamu.
+
+    :param soubory: Iterovatelná kolekce souborů.
+    :return: Soubor s nejnižším řadicím klíčem názvu, nebo None pro prázdný vstup.
+    """
+    soubory = list(soubory)
+    if not soubory:
+        return None
+    return min(soubory, key=soubor_nazev_razeni_klic)
+
+
 class Soubor(ExportModelOperationsMixin("soubor"), models.Model):
     """Model pro soubor. Obsahuje jeho základné data, vazbu na historii a souborovů vazbu."""
 

--- a/webclient/core/models.py
+++ b/webclient/core/models.py
@@ -129,10 +129,10 @@ def soubor_nazev_razeni_klic(soubor):
     """
     Vrátí řadicí klíč souboru podle názvu.
 
-    Tečka je nahrazena znakem ``0``, aby se soubory řadily shodně s výpisem souborů
-    v detailu záznamu (např. ``nazev.jpg`` před ``nazev-2.jpg``). Používá se pro
-    jednotné určení pořadí souborů i výběr náhledového souboru napříč dokumenty,
-    3D modely i samostatnými nálezy.
+    Při porovnání se tečka chová jako znak ``0``, což zachovává dosavadní pořadí
+    výpisu souborů v detailu záznamu (např. ``foto.jpg`` před ``foto2.jpg``). Používá
+    se pro jednotné určení pořadí souborů i výběr náhledového souboru napříč
+    dokumenty, 3D modely i samostatnými nálezy.
 
     :param soubor: Soubor, z jehož názvu se klíč sestaví.
     :return: N-tice použitelná jako ``key`` pro ``sorted`` nebo ``min``.

--- a/webclient/core/tests/test_soubor_razeni.py
+++ b/webclient/core/tests/test_soubor_razeni.py
@@ -1,0 +1,127 @@
+"""
+Testy sdíleného řazení souborů podle názvu.
+
+Pokrývají :func:`core.models.soubor_nazev_razeni_klic` a
+:func:`core.models.prvni_soubor_dle_nazvu`, které jednotně určují pořadí souborů
+a výběr náhledového souboru napříč dokumenty, 3D modely i samostatnými nálezy.
+"""
+
+from core.models import prvni_soubor_dle_nazvu, soubor_nazev_razeni_klic
+from django.test import SimpleTestCase
+
+
+class _SouborStub:
+    """Odlehčená náhrada za :class:`core.models.Soubor` nesoucí pouze název."""
+
+    def __init__(self, nazev):
+        """
+        Inicializuje stub souboru.
+
+        :param nazev: Název souboru použitý pro řazení.
+        """
+        self.nazev = nazev
+
+    def __repr__(self):
+        """
+        Vrátí čitelnou reprezentaci pro výstup testů.
+
+        :return: Reprezentace obsahující název souboru.
+        """
+        return f"_SouborStub({self.nazev!r})"
+
+
+class SouborNazevRazeniKlicTest(SimpleTestCase):
+    """Testuje řadicí klíč :func:`soubor_nazev_razeni_klic`."""
+
+    def test_klic_nahrazuje_tecku_nulou(self):
+        """Ověří, že klíč porovnává tečku jako znak ``0`` a zachová původní název."""
+        self.assertEqual(soubor_nazev_razeni_klic(_SouborStub("foto.jpg")), ("foto0jpg", "foto.jpg"))
+
+    def test_zaklad_pred_ciselnym_suffixem_bez_pomlcky(self):
+        """``foto.jpg`` se řadí před ``foto2.jpg`` (tečka jako ``0`` je menší než ``2``)."""
+        soubory = [_SouborStub("foto2.jpg"), _SouborStub("foto.jpg")]
+        self.assertEqual([s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)], ["foto.jpg", "foto2.jpg"])
+
+    def test_pomlckovy_suffix_pred_zakladem(self):
+        """``foto-2.jpg`` se řadí před ``foto.jpg`` (pomlčka je menší než ``0``)."""
+        soubory = [_SouborStub("foto.jpg"), _SouborStub("foto-2.jpg")]
+        self.assertEqual([s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)], ["foto-2.jpg", "foto.jpg"])
+
+
+class PrvniSouborDleNazvuTest(SimpleTestCase):
+    """Testuje výběr náhledového souboru :func:`prvni_soubor_dle_nazvu`."""
+
+    def test_prazdny_vstup_vraci_none(self):
+        """Prázdná kolekce vrátí ``None``."""
+        self.assertIsNone(prvni_soubor_dle_nazvu([]))
+
+    def test_vybere_prvni_dle_klice(self):
+        """Vybere soubor s nejnižším řadicím klíčem názvu bez ohledu na vstupní pořadí."""
+        soubory = [_SouborStub("C-3D-x.jpg"), _SouborStub("C-3D-x-b.jpg"), _SouborStub("C-3D-x-a.jpg")]
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C-3D-x-a.jpg")
+
+    def test_vyber_odpovida_serazeni(self):
+        """Vybraný soubor je totožný s prvním prvkem ``sorted`` podle stejného klíče."""
+        soubory = [_SouborStub("b.jpg"), _SouborStub("a-1.jpg"), _SouborStub("a.jpg")]
+        serazene = sorted(soubory, key=soubor_nazev_razeni_klic)
+        self.assertIs(prvni_soubor_dle_nazvu(soubory), serazene[0])
+
+    def test_prijima_generator(self):
+        """Funkce zvládne i neopakovatelný iterátor (generátor)."""
+        soubory = (_SouborStub(n) for n in ["z.jpg", "a.jpg", "m.jpg"])
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "a.jpg")
+
+
+class RealneNazvySouboruTest(SimpleTestCase):
+    """Testuje řazení na reálných názvech souborů používaných v aplikaci."""
+
+    def test_dokument_foto_serie_F(self):
+        """Fotografie dokumentu ``...F01``–``...F03`` se řadí vzestupně a náhled je ``F01``."""
+        soubory = [
+            _SouborStub("C201911202N00047F03.jpg"),
+            _SouborStub("C201911202N00047F01.jpg"),
+            _SouborStub("C201911202N00047F02.jpg"),
+        ]
+        self.assertEqual(
+            [s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)],
+            [
+                "C201911202N00047F01.jpg",
+                "C201911202N00047F02.jpg",
+                "C201911202N00047F03.jpg",
+            ],
+        )
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C201911202N00047F01.jpg")
+
+    def test_foto_serie_zachova_poradi_pri_dvouciferne_nule(self):
+        """Nula doplněné pořadí (``F01``–``F10``) se řadí správně i pro dvojciferný index."""
+        soubory = [
+            _SouborStub("C201911202N00047F10.jpg"),
+            _SouborStub("C201911202N00047F02.jpg"),
+            _SouborStub("C201911202N00047F01.jpg"),
+        ]
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C201911202N00047F01.jpg")
+
+    def test_dokument_pdf_pismenny_suffix(self):
+        """PDF s písmenným suffixem ``A``–``C`` se řadí abecedně a náhled je ``A``."""
+        soubory = [
+            _SouborStub("XCDD000000009B.pdf"),
+            _SouborStub("XCDD000000009A.pdf"),
+            _SouborStub("XCDD000000009C.pdf"),
+        ]
+        self.assertEqual(
+            [s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)],
+            [
+                "XCDD000000009A.pdf",
+                "XCDD000000009B.pdf",
+                "XCDD000000009C.pdf",
+            ],
+        )
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "XCDD000000009A.pdf")
+
+    def test_ruzne_zaklady_nazvu(self):
+        """Soubory s odlišným základem názvu se řadí podle celého názvu."""
+        soubory = [
+            _SouborStub("XCDD000000009A.pdf"),
+            _SouborStub("C201911202N00047F03.jpg"),
+        ]
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C201911202N00047F03.jpg")

--- a/webclient/core/utils.py
+++ b/webclient/core/utils.py
@@ -1275,13 +1275,11 @@ class SearchTable(ColumnShiftTableBootstrap4):
 
             :return: Vrací hodnotu podle větve zpracování, typicky: výsledek volání ``format_html()``, str.
         """
+        from core.models import prvni_soubor_dle_nazvu
         from pas.models import SamostatnyNalez
 
         record: SamostatnyNalez
-        if record.soubory.soubory.count() > 0:
-            soubor = record.soubory.soubory.first()
-        else:
-            soubor = None
+        soubor = prvni_soubor_dle_nazvu(record.soubory.soubory.all())
         if soubor is not None:
             from core.models import Soubor
 

--- a/webclient/dokument/models.py
+++ b/webclient/dokument/models.py
@@ -22,7 +22,7 @@ from core.constants import (
     ZAPSANI_DOK,
 )
 from core.exceptions import MaximalIdentNumberError, UnexpectedDataRelations
-from core.models import ModelWithMetadata, Soubor, SouborVazby
+from core.models import ModelWithMetadata, Soubor, SouborVazby, prvni_soubor_dle_nazvu
 from django.conf import settings
 from django.contrib.gis.db.models import PointField
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -540,14 +540,11 @@ class Dokument(ExportModelOperationsMixin("dokument"), ModelWithMetadata):
     @property
     def thumbnail_image_file(self) -> Soubor | None:
         """
-        Vrací první soubor jako náhled (seřazeny abecedně).
+        Vrací první soubor jako náhled (seřazeno podle názvu shodně s výpisem souborů).
 
         :return: První seřazený soubor nebo None.
         """
-        if self.soubory.soubory.count() > 0:
-            soubory = [x for x in self.soubory.soubory.all()]
-            soubory = list(sorted(soubory, key=lambda x: x.nazev))
-            return soubory[0]
+        return prvni_soubor_dle_nazvu(self.soubory.soubory.all())
 
     @cached_property
     def large_thumbnail(self):

--- a/webclient/dokument/tables.py
+++ b/webclient/dokument/tables.py
@@ -1,7 +1,7 @@
 import logging
 
 import django_tables2 as tables
-from core.models import Soubor
+from core.models import Soubor, prvni_soubor_dle_nazvu
 from core.utils import SearchTable
 from django.urls import reverse
 from django.utils.html import format_html
@@ -111,10 +111,7 @@ class Model3DTable(SearchTable):
         :param record: Záznam s daty modelu 3D.
         :return: HTML řetězec s náhledem nebo prázdný řetězec.
         """
-        if len(record.soubory.soubory.all()) > 0:
-            soubor = record.soubory.soubory.first()
-        else:
-            soubor = None
+        soubor = prvni_soubor_dle_nazvu(record.soubory.soubory.all())
         if soubor is not None:
             soubor: Soubor
             thumbnail_url = reverse(
@@ -125,8 +122,8 @@ class Model3DTable(SearchTable):
                     soubor.id,
                 ),
             )
-            soubor_url = reverse(
-                "core:download_file",
+            thumbnail_large_url = reverse(
+                "core:download_thumbnail_large",
                 args=(
                     "model3d",
                     record.ident_cely,
@@ -137,7 +134,7 @@ class Model3DTable(SearchTable):
                 '<img src="{}" class="image-nahled" data-bs-toggle="modal" data-bs-target="#soubor-modal" loading="lazy" data-fullsrc="{}" '
                 'style="opacity:0" onload="this.style.opacity=100">',
                 thumbnail_url,
-                soubor_url,
+                thumbnail_large_url,
             )
         return ""
 
@@ -262,8 +259,8 @@ class DokumentTable(SearchTable):
         :param record: Záznam s daty modelu 3D.
         :return: HTML řetězec s náhledem nebo prázdný řetězec.
         """
-        if hasattr(record.soubory, "first_soubor") and len(record.soubory.first_soubor) > 0:
-            soubor = record.soubory.first_soubor[0]
+        if hasattr(record.soubory, "soubory_nahled"):
+            soubor = prvni_soubor_dle_nazvu(record.soubory.soubory_nahled)
         else:
             soubor = None
         if soubor is not None:

--- a/webclient/dokument/views.py
+++ b/webclient/dokument/views.py
@@ -55,7 +55,7 @@ from core.message_constants import (
     ZAZNAM_USPESNE_VYTVOREN,
 )
 from core.models import Permissions as p
-from core.models import Soubor, check_permissions
+from core.models import Soubor, check_permissions, soubor_nazev_razeni_klic
 from core.repository_connector import FedoraError, FedoraRepositoryConnector, FedoraTransaction
 from core.utils import TwoQueryPaginator, get_3d_from_envelope
 from core.views import PermissionFilterMixin, SearchListView, check_stav_changed
@@ -67,7 +67,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import IntegrityError, transaction
-from django.db.models import OuterRef, Prefetch, Q, Subquery
+from django.db.models import Prefetch, Q
 from django.forms import inlineformset_factory
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -244,7 +244,7 @@ def detail_model_3D(request, ident_cely):
     context["show"] = show
     context["global_map_can_edit"] = False
     if dokument.soubory:
-        context["soubory"] = sorted(dokument.soubory.soubory.all(), key=lambda x: (x.nazev.replace(".", "0"), x.nazev))
+        context["soubory"] = sorted(dokument.soubory.soubory.all(), key=soubor_nazev_razeni_klic)
     else:
         context["soubory"] = None
     return render(request, "dokument/detail_model_3D.html", context)
@@ -453,7 +453,6 @@ class DokumentListView(SearchListView):
         sort_params = [self.rename_field_for_ordering(x) for x in sort_params]
         qs = super().get_queryset()
         qs = qs.order_by(*sort_params)
-        subqry = Subquery(Soubor.objects.filter(vazba=OuterRef("vazba")).values_list("id", flat=True)[:1])
         qs = qs.exclude(typ_dokumentu__id__in=MODEL_3D_DOKUMENT_TYPES)
         qs = (
             qs.select_related(
@@ -471,8 +470,8 @@ class DokumentListView(SearchListView):
             .prefetch_related(
                 Prefetch(
                     "soubory__soubory",
-                    queryset=Soubor.objects.filter(id__in=subqry),
-                    to_attr="first_soubor",
+                    queryset=Soubor.objects.only("id", "nazev", "vazba"),
+                    to_attr="soubory_nahled",
                 ),
                 Prefetch(
                     "autori",
@@ -641,9 +640,7 @@ class RelatedContext(LoginRequiredMixin, TemplateView):
         context["show"] = show
 
         if dokument.soubory:
-            context["soubory"] = sorted(
-                dokument.soubory.soubory.all(), key=lambda x: (x.nazev.replace(".", "0"), x.nazev)
-            )
+            context["soubory"] = sorted(dokument.soubory.soubory.all(), key=soubor_nazev_razeni_klic)
         else:
             context["soubory"] = None
 

--- a/webclient/pas/models.py
+++ b/webclient/pas/models.py
@@ -16,7 +16,7 @@ from core.constants import (
     VRACENI_SN,
     ZAPSANI_SN,
 )
-from core.models import ModelWithMetadata, SouborVazby
+from core.models import ModelWithMetadata, SouborVazby, prvni_soubor_dle_nazvu
 from django.conf import settings
 from django.contrib.gis.db import models as pgmodels
 from django.db import models
@@ -336,15 +336,12 @@ class SamostatnyNalez(ExportModelOperationsMixin("samostatny_nalez"), ModelWithM
     @property
     def nahled_soubor(self):
         """
-        Vrací cestu k miniaturnímu náhledu souboru.
+        Vrací náhledový soubor (první podle názvu, shodně s výpisem souborů).
 
         :return: První soubor nebo None, pokud žádný neexistuje.
 
         """
-        if self.soubory.soubory.count() > 0:
-            return self.soubory.soubory.first()
-        else:
-            return None
+        return prvni_soubor_dle_nazvu(self.soubory.soubory.all())
 
     @cached_property
     def large_thumbnail(self):

--- a/webclient/pas/views.py
+++ b/webclient/pas/views.py
@@ -45,7 +45,7 @@ from core.message_constants import (
     ZAZNAM_USPESNE_VYTVOREN,
 )
 from core.models import Permissions as p
-from core.models import check_permissions
+from core.models import check_permissions, soubor_nazev_razeni_klic
 from core.repository_connector import FedoraError, FedoraRepositoryConnector, FedoraTransaction
 from core.utils import TwoQueryPaginator, get_cadastre_from_point, get_cadastre_from_point_with_geometry
 from core.views import PermissionFilterMixin, SearchListView, check_stav_changed
@@ -104,7 +104,7 @@ def get_detail_context(sn, request):
     context["history_dates"] = get_history_dates(sn.historie, request.user)
     context["show"] = get_detail_template_shows(sn, request.user)
     if sn.soubory:
-        context["soubory"] = sorted(sn.soubory.soubory.all(), key=lambda x: (x.nazev.replace(".", "0"), x.nazev))
+        context["soubory"] = sorted(sn.soubory.soubory.all(), key=soubor_nazev_razeni_klic)
     else:
         context["soubory"] = None
     context["app"] = "pas"


### PR DESCRIPTION
<!-- aiscr-review-pr:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4152

| Field | Value |
| --- | --- |
| Title | Úprava řazení náhledů |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4152 |
| Author | jhavrlant |
| Base ← head | test ← bugfix/4150-nahled-dokument |
| Head SHA | [821c9fa](https://github.com/ARUP-CAS/aiscr-webamcr/commit/821c9fa9fbe9fffac36bf1337587de06934c39e1) |
| Size | 11 files, +205 / −39, 2 commits |
| State | open; mergeable; merge state blocked pending follow-up disposition |
| Marked AIS CR review baseline | motyc APPROVED on e5b6ca4 (`<!-- aiscr-review-pr:v1 -->`) |
| Prior PR summary | marked summary already in PR description (stale vs current head) |

## Purpose and scope

Fixes [#4150](https://github.com/ARUP-CAS/aiscr-webamcr/issues/4150): document and 3D thumbnail selection followed database / PK order (or plain alphabetical sort) instead of the same name-based order used in the detail file list, so renaming a file did not change which thumbnail appeared. The PR also corrects the 3D list modal `data-fullsrc` so it opens the large thumbnail endpoint instead of downloading the original file. A follow-up commit adds unit tests for the shared sort helpers.

## Change map by area

| Area | Files | What changed |
| --- | --- | --- |
| Shared helpers | `webclient/core/models.py` | Adds `soubor_nazev_razeni_klic` (`.` → `0` sort key) and `prvni_soubor_dle_nazvu` |
| Tests | `webclient/core/tests/test_soubor_razeni.py` | New `SimpleTestCase` coverage for the sort key, first-file pick, generators, and realistic AMCR filenames |
| Dokument / 3D | `dokument/models.py`, `tables.py`, `views.py` | Thumbnail pick and detail file lists use the shared key; list Prefetch becomes `soubory_nahled`; Model3D modal uses `download_thumbnail_large` |
| PAS | `pas/models.py`, `pas/views.py`, `core/utils.py` | Detail list and `nahled_soubor` / PAS table helper use the same helpers |
| Docs | `docs/source/.../core|dokument|pas/models.rst` | Documents the new helpers and updated property wording |

## Change walkthrough

Call sites that previously used `.first()`, a one-row Subquery Prefetch, or `sorted(..., key=lambda x: x.nazev)` now share one sort key that matches the detail UI (`nazev.jpg` before `nazev-2.jpg`). Document list views prefetch all related `Soubor` rows (id/nazev/vazba only) into `soubory_nahled` and pick the minimum key in Python. Model3D list modal full-src switches from `core:download_file` to `core:download_thumbnail_large`. The second commit adds focused unit tests for the helpers without changing production call sites again.

```mermaid
flowchart TD
  files[Soubor rows for record] --> keyFn["soubor_nazev_razeni_klic"]
  keyFn --> pick["prvni_soubor_dle_nazvu / sorted"]
  pick --> thumb[Small / large thumbnail URLs]
  pick --> detail[Detail file list order]
  pick --> tests[test_soubor_razeni.py]
```

## Attention hints (summary only)

- Document list Prefetch still loads every related file (narrow columns); author reports the performance impact as negligible.
- Model3D list still prefetches full `soubory__soubory` while Dokument list uses `soubory_nahled` — both name-sorted, query shapes differ.
- PAS `nahled_soubor` uses name order for alignment with detail lists; multi-file PAS rows may differ from prior PK-order thumbnails.

## Validation / test surfaces visible in the PR

- Visible in the PR: new `webclient/core/tests/test_soubor_razeni.py`; Sphinx model docs updated; GitHub Actions pre-commit and CodeQL checks reported success on the current head ([pre-commit run 29732911717](https://github.com/ARUP-CAS/aiscr-webamcr/actions/runs/29732911717)).
- Not evidenced in the PR: automated coverage of the Model3D modal URL change (`download_file` → `download_thumbnail_large`); no manual QA notes in author comments beyond asserting negligible remaining impact.
- Executed during this review: public API metadata/diff fetch, local `git fetch` + diff against `origin/test...origin/bugfix/4150-nahled-dokument` at `821c9fa`, Cursor Bugbot pass (no bugs). App runtime / UI not executed here.

## Lineage

Second AIS CR review round. Prior marked baseline is motyc APPROVED on `e5b6ca4`. Author replied that tests were added and remaining notes are negligible; inline reply on the Prefetch thread states performance impact is negligible. Prior marked summary remains in the PR description and is stale relative to the new head and test commit.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
