### PR TITLE
Oprava chyby při pokusu připojit stejný dokument ze dvou akcí souběžně

### DIFF
--- a/webclient/dokument/views.py
+++ b/webclient/dokument/views.py
@@ -2754,33 +2754,41 @@ def pripojit(request, ident_zaznam, proj_ident_cely, typ):
             fedora_transaction = zaznam.create_transaction(request.user)
             try:
                 for dokument_id in dokument_ids:
-                    dokument = get_object_or_404(Dokument, id=dokument_id)
-                    dokument.active_transaction = fedora_transaction
-                    relace = casti_zaznamu.filter(dokument__id=dokument_id)
-                    if not relace.exists():
-                        dc_ident = get_cast_dokumentu_ident(dokument)
-                        if isinstance(zaznam, ArcheologickyZaznam):
-                            dc = DokumentCast(
-                                archeologicky_zaznam=zaznam,
-                                dokument=dokument,
-                                ident_cely=dc_ident,
+                    with transaction.atomic():
+                        # Zámek řádku dokumentu serializuje souběžné připojení téhož dokumentu –
+                        # jinak oba requesty spočítají v get_cast_dokumentu_ident stejné pořadové
+                        # číslo části a druhý insert spadne na unique constraint (IntegrityError, #4141).
+                        dokument = get_object_or_404(Dokument.objects.select_for_update(), id=dokument_id)
+                        dokument.active_transaction = fedora_transaction
+                        relace = casti_zaznamu.filter(dokument__id=dokument_id)
+                        if not relace.exists():
+                            dc_ident = get_cast_dokumentu_ident(dokument)
+                            if isinstance(zaznam, ArcheologickyZaznam):
+                                dc = DokumentCast(
+                                    archeologicky_zaznam=zaznam,
+                                    dokument=dokument,
+                                    ident_cely=dc_ident,
+                                )
+                            else:
+                                dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
+                            dc.active_transaction = fedora_transaction
+                            dc.save()
+                            dokument.save()
+                            logger.debug(
+                                "dokument.views.pripojit.pripojit",
+                                extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
+                            )
+                            messages.add_message(
+                                request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
                             )
                         else:
-                            dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
-                        dc.active_transaction = fedora_transaction
-                        dc.save()
-                        dokument.save()
-                        logger.debug(
-                            "dokument.views.pripojit.pripojit",
-                            extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
-                        )
-                        messages.add_message(
-                            request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
-                        )
-                    else:
-                        messages.add_message(
-                            request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
-                        )
+                            messages.add_message(
+                                request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
+                            )
+            except FedoraError:
+                # Souběžná úprava téhož záznamu (Fedora 409) apod. – necháme probublat do
+                # dekorátoru handle_fedora_error, který vrátí čistou odpověď a zrolluje transakci.
+                raise
             except Exception as err:
                 logger.error("dokument.views.pripojit.error", extra={"error": err, "ident_cely": dokument.ident_cely})
                 transaction.set_rollback(True)

--- a/webclient/dokument/views.py
+++ b/webclient/dokument/views.py
@@ -2753,7 +2753,9 @@ def pripojit(request, ident_zaznam, proj_ident_cely, typ):
         if len(dokument_ids) > 0:
             fedora_transaction = zaznam.create_transaction(request.user)
             try:
-                for dokument_id in dokument_ids:
+                # Deterministické pořadí zamykání – dvě souběžné dávky sdílející dokumenty
+                # by při opačném pořadí jinak mohly na select_for_update uváznout (deadlock).
+                for dokument_id in sorted(dokument_ids):
                     with transaction.atomic():
                         # Zámek řádku dokumentu serializuje souběžné připojení téhož dokumentu –
                         # jinak oba requesty spočítají v get_cast_dokumentu_ident stejné pořadové


### PR DESCRIPTION
<!-- aiscr-review-pr:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4153

| Field | Value |
| --- | --- |
| Title | Oprava chyby při pokusu připojit stejný dokument ze dvou akcí souběžně |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4153 |
| Author | jhavrlant |
| Base ← head | `test` ← `bugfix/4141` |
| Head SHA | `d2785de6aa038740f4c475570fb0ecde8534c9fe` |
| Size | 1 file, +36 / −26 |
| State | OPEN |
| Marked AIS CR review baseline | review `4735686855` (motyc, 2026-07-20) — Medium lock-order finding; author replied “Opraveno” |
| Prior PR summary | marked summary already in PR description (round 1, head `fab8691`) |

## Purpose and scope

Fixes [#4141](https://github.com/ARUP-CAS/aiscr-webamcr/issues/4141): concurrent `pripojit` requests attaching the same document could allocate the same next `DokumentCast.ident_cely` in `get_cast_dokumentu_ident`, and the second insert hit a unique-constraint `IntegrityError` (observed as a 500 in Elastic).

Scope remains narrow: only the POST path of `pripojit` in `webclient/dokument/views.py`. No schema, API, or UI template changes. Follow-up commit `d2785de` sorts `dokument_ids` before locking to address the prior multi-document deadlock finding.

## Change map by area

| Area | Files / Δ | What changed |
| --- | --- | --- |
| `dokument/views.py` → `pripojit` | 1 file, +36 / −26 | `sorted(dokument_ids)` then per-id `transaction.atomic()` + `Dokument.objects.select_for_update()` before identity allocation and insert; re-raise `FedoraError` for `@handle_fedora_error` |

## Change walkthrough

Concurrent attach of one document is serialized by a PostgreSQL row lock on `Dokument` before `get_cast_dokumentu_ident` reads `dokument.casti`. Multi-document POSTs now iterate ids in sorted order so opposite-order concurrent batches cannot form an AB–BA deadlock while holding `select_for_update` locks under `ATOMIC_REQUESTS=True`. Per-iteration `atomic()` blocks remain savepoints inside the request transaction. `FedoraError` is re-raised so the existing decorator can handle Fedora 409-style conflicts instead of being swallowed by the generic `except Exception` path.

```mermaid
sequenceDiagram
  participant A as Request A docs 1 then 2
  participant B as Request B docs 2 then 1
  participant DB as PostgreSQL
  Note over A,B: Both sort ids before locking
  A->>DB: SELECT FOR UPDATE Dokument 1
  B->>DB: SELECT FOR UPDATE Dokument 1
  Note over B,DB: B waits (same first lock key)
  A->>DB: lock Dokument 2 then commit request
  B->>DB: lock granted then proceeds in sorted order
```

## Attention hints (summary only)

- Confirm the lock key (`Dokument` row) still matches cast-suffix allocation via `dokument.casti`.
- Sorting removes AB–BA deadlock risk; locking the whole id set up front was optional hardening and is not in this tip.
- Other `get_cast_dokumentu_ident` call sites (create-document / create-cast flows) remain unlocked; out of scope for this PR’s stated fix.

## Validation / test surfaces visible in the PR

- Visible in PR / CI: pre-commit passed; CodeQL / Analyze (actions, javascript, python) passed; GitGuardian passed. No new unit or concurrency tests in the diff.
- Executed during this review: `gh pr view` / `gh pr diff` / `gh pr checks`; gather via `review_pr.py`; static review of tip `pripojit`, `get_cast_dokumentu_ident`, and `ATOMIC_REQUESTS`; Cursor Bugbot on the tip (no bugs). No app test suite or live concurrency reproduction was run.

## Lineage

Second AIS CR review round for head `d2785de`. Prior marked review raised one Medium finding (deterministic multi-document lock order); author replied “Opraveno” on the inline thread and pushed the sort fix. Marked summary already lives in the PR description at the previous head. Auxiliary: GitHub Actions pre-commit bot comment only.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
