### PR TITLE
bug/2322-opravy

### DIFF
--- a/webclient/core/templates/core/export_modal.html
+++ b/webclient/core/templates/core/export_modal.html
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="modal" tabindex="-1" role="dialog" id="export-progress-modal">
     <div class="modal-dialog" role="document">
-      <div class="modal-content" style="background-color: white">
+      <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">{% trans "core.templates.core.export-modal.title" %}</h5>
         </div>

--- a/webclient/static/scss/_app-theme-dark.scss
+++ b/webclient/static/scss/_app-theme-dark.scss
@@ -23,17 +23,6 @@ body.app-dark-theme {
     color: $body-text-dark;
     background-color: $body-bg-dark;
 
-    @include setEntityTransakceColor($dark-entities);
-
-    .app-entity-cards {
-        .col {
-
-            .app-card-entity {
-                @include setEntityColor("card", $dark-entities, null);
-            }
-        }
-    }
-
     // Sidebar
     .app-sidebar-wrapper {
         background-color: $app-sidebar-bg-dark;
@@ -143,29 +132,115 @@ body.app-dark-theme {
     }
 
     #app-page-wrapper .container-fluid.app-content-wrapper {
-        @include setEntityElementsColor($dark-entities);
-        background-color: $body-bg-dark;
+        @each $entity, $color in $dark-entities {
+            .app-entity-#{$entity} {
+                .app-table-list-wrapper {
+                    .table {
+                        thead {
+                            position: sticky;
+                            top: 0;
+                            --bs-table-bg: #{$color} !important;
 
-        .app-toolbar {
-            background-color: $app-toolbar-bg-dark !important;
+                            a {
+                                color: $white;
+                            }
 
-            .app-left {
-                .app-entity-item {
-                    color: $body-text-dark;
+                            .white {
+                                color: $white;
+                            }
+                        }
 
-                    .material-icons,
-                    button span.material-icons {
-                        color: $body-text-dark;
+                        tbody {
+                            a {
+                                color: $color;
+                            }
+
+                            button {
+                                color: $color;
+                            }
+
+                            td {
+                                vertical-align: middle;
+                            }
+                        }
                     }
                 }
 
-                .igsn span,
-                .backdetail a,
-                .doi span {
-                    color: $body-text-dark;
+                // pagination
+                .pagination {
+                    .page-item {
+                        &.active {
+                            .page-link {
+                                background-color: $color;
+                                border: $color;
+                                color: $white;
+                                display: flex;
+                                border: 1px solid #dee2e6;
+                            }
+                        }
+
+                        .page-link {
+                            color: $color;
+                            display: flex;
+                        }
+                    }
+                }
+            }
+
+            .app-card-#{$entity} {
+                table {
+                    tr {
+                        td {
+                            &.app-ident-cely {
+                                color: $color !important;
+
+                                .material-icons {
+                                    color: $color;
+                                }
+
+                                a {
+                                    color: $color;
+                                }
+                            }
+
+                            &.app-cell-badge {
+                                padding-left: 0;
+                            }
+
+                            .badge {
+                                background-color: $color !important;
+                                color: $white;
+                            }
+                        }
+                    }
+                }
+            }
+
+            background-color: $body-bg-dark;
+
+            .app-toolbar {
+                background-color: $app-toolbar-bg-dark !important;
+
+                .app-left {
+                    .app-entity-item {
+                        color: $body-text-dark;
+
+                        .material-icons,
+                        button span.material-icons {
+                            color: $body-text-dark;
+                        }
+                    }
+
+                    .igsn span,
+                    .backdetail a,
+                    .doi span {
+                        color: $body-text-dark;
+                    }
                 }
             }
         }
+
+
 
         .app-right .btn-group .btn {
             color: $body-text-dark;
@@ -181,6 +256,10 @@ body.app-dark-theme {
 
         .uiElement.label {
             color: $gray-100-dark;
+        }
+
+        .leaflet-draw-actions a {
+            color: $body-text-dark !important;
         }
     }
 
@@ -221,6 +300,10 @@ body.app-dark-theme {
 
         .card-body {
             color: $body-text-dark;
+
+            .material-icons {
+                color: $body-text-dark;
+            }
         }
     }
 

--- a/webclient/static/scss/_app-theme-dark.scss
+++ b/webclient/static/scss/_app-theme-dark.scss
@@ -172,7 +172,6 @@ body.app-dark-theme {
                         &.active {
                             .page-link {
                                 background-color: $color;
-                                border: $color;
                                 color: $white;
                                 display: flex;
                                 border: 1px solid #dee2e6;
@@ -216,26 +215,27 @@ body.app-dark-theme {
                 }
             }
 
-            background-color: $body-bg-dark;
+        }
 
-            .app-toolbar {
-                background-color: $app-toolbar-bg-dark !important;
+        background-color: $body-bg-dark;
 
-                .app-left {
-                    .app-entity-item {
-                        color: $body-text-dark;
+        .app-toolbar {
+            background-color: $app-toolbar-bg-dark !important;
 
-                        .material-icons,
-                        button span.material-icons {
-                            color: $body-text-dark;
-                        }
-                    }
+            .app-left {
+                .app-entity-item {
+                    color: $body-text-dark;
 
-                    .igsn span,
-                    .backdetail a,
-                    .doi span {
+                    .material-icons,
+                    button span.material-icons {
                         color: $body-text-dark;
                     }
+                }
+
+                .igsn span,
+                .backdetail a,
+                .doi span {
+                    color: $body-text-dark;
                 }
             }
         }


### PR DESCRIPTION
<!-- aiscr-review-pr:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4154

| Field | Value |
| --- | --- |
| Title | bug/2322-opravy |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4154 |
| Author | @jnihnat |
| Base ← head | `test` ← `bug/2322_opvary` |
| Head SHA | `30d62b7ef68939f2b1c0a4fc08afaf2506443fc0` |
| Size | +96 / −13 across 2 files |
| State | OPEN |
| Marked AIS CR review baseline | motyc review on `670c549` (`<!-- aiscr-review-pr:v1 -->`) |
| Prior PR summary | marked summary in PR description (stale: still cites `670c549`) |

## Purpose and scope

Dark-mode visual fixes for [#2322](https://github.com/ARUP-CAS/aiscr-webamcr/issues/2322): Material Icons contrast, entity accent colors scoped to tables/lister (instead of broader entity mixins), export-progress modal background, and Leaflet draw-action label color on the map. Follow-up commit `30d62b7` addresses the first marked AIS CR review comments.

## Change map by area

| Area | Files | What changed |
| --- | --- | --- |
| Export modal | `webclient/core/templates/core/export_modal.html` | Removed hardcoded `background-color: white` from `.modal-content` so theme CSS can control the surface. |
| Dark theme SCSS | `webclient/static/scss/_app-theme-dark.scss` | Replaced broad entity mixins with an `@each`-driven table/pagination/card-ident path; toolbar and wrapper background sit outside the loop; Leaflet draw-action and card-body Material Icons use `$body-text-dark`; follow-up removes duplicate active-pagination `border` and extracts non-entity rules from `@each`. |

## Change walkthrough

The modal change remains a one-line theme unblock. The SCSS change drops dark-mode `@include setEntityTransakceColor` / entity-card recolor and the content-wrapper `setEntityElementsColor` mixin. Under `body.app-dark-theme` → `.app-content-wrapper`, an `@each` over `$dark-entities` paints entity color only onto list-table headers/links, pagination, and card identity/badge cells. After the first review, wrapper `background-color` and `.app-toolbar` (including Material Icons and IGSN/DOI/backdetail text) live as siblings below that `@each`. Map UI forces `.leaflet-draw-actions a` onto dark body text; stepper/card bodies force Material Icons the same way.

```mermaid
flowchart TD
  dark["body.app-dark-theme"]
  modal["export_modal: drop white background"]
  scss["_app-theme-dark.scss"]
  each["@each entity: tables / pagination / card idents"]
  shared["wrapper bg + toolbar outside loop"]
  icons["Material Icons + Leaflet draw labels"]
  dark --> modal
  dark --> scss
  scss --> each
  scss --> shared
  scss --> icons
```

## Attention hints (summary only)

- Entity coloring remains intentionally narrowed to tables/cards-in-tables; non-table entity chrome from the old mixins is no longer restyled that way.
- Active pagination still uses `border: 1px solid #dee2e6` (light-theme gray) after the duplicate `border: $color` was removed.
- No compiled CSS or screenshot evidence is attached in the PR itself.

## Validation / test surfaces visible in the PR

- Visible in the PR: pre-commit, CodeQL, and Analyze jobs reported success against the PR head; GitGuardian reported success.
- Not evidenced in the PR: compiled SCSS/CSS artifact review, visual regression screenshots, or a written browser dark-mode walkthrough.
- Executed during this review session so far: `gh pr view` / `gather` / `gh pr diff` / head-file inspection and Bugbot-assisted diff analysis (no local SCSS compile or UI run).

## Lineage

Newest marked AIS CR review: motyc on head `670c549` (two Minor inlines: duplicate pagination `border`; wrapper/toolbar rules inside `@each`). Author replied `fixed` on both threads and pushed `30d62b7` (“fix pr comments”). Auxiliary: @jhavrlant APPROVED on `670c549`. Prior marked summary lives in the PR description and is stale relative to the new head.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
