### PR TITLE
v1.4.0-rc1

### DIFF
--- a/docs/source/04_django_aplikace/04_02_moduly/core/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/core/models.rst
@@ -326,6 +326,28 @@ Funkce
    :param filename: Název souboru.
    :return: Cesta pro uložení souboru.
 
+.. py:function:: soubor_nazev_razeni_klic(soubor)
+
+   Vrátí řadicí klíč souboru podle názvu.
+
+   Při porovnání se tečka chová jako znak ``0``, což zachovává dosavadní pořadí
+   výpisu souborů v detailu záznamu (např. ``foto.jpg`` před ``foto2.jpg``). Používá
+   se pro jednotné určení pořadí souborů i výběr náhledového souboru napříč
+   dokumenty, 3D modely i samostatnými nálezy.
+
+   :param soubor: Soubor, z jehož názvu se klíč sestaví.
+   :return: N-tice použitelná jako ``key`` pro ``sorted`` nebo ``min``.
+
+.. py:function:: prvni_soubor_dle_nazvu(soubory)
+
+   Vrátí náhledový soubor jako první soubor seřazený podle názvu.
+
+   Pořadí odpovídá výpisu souborů v detailu (viz :func:`soubor_nazev_razeni_klic`),
+   takže náhled je vždy první soubor v seznamu.
+
+   :param soubory: Iterovatelná kolekce souborů.
+   :return: Soubor s nejnižším řadicím klíčem názvu, nebo None pro prázdný vstup.
+
 .. py:function:: check_permissions(action, user, ident, skip_status)
 
    Ověří permissions. v aplikaci.

--- a/docs/source/04_django_aplikace/04_02_moduly/dokument/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/dokument/models.rst
@@ -152,7 +152,7 @@ Třídy
 
    .. py:method:: thumbnail_image_file()
 
-      Vrací první soubor jako náhled (seřazeny abecedně).
+      Vrací první soubor jako náhled (seřazeno podle názvu shodně s výpisem souborů).
 
       :return: První seřazený soubor nebo None.
 

--- a/docs/source/04_django_aplikace/04_02_moduly/pas/models.rst
+++ b/docs/source/04_django_aplikace/04_02_moduly/pas/models.rst
@@ -99,7 +99,7 @@ Třídy
 
    .. py:method:: nahled_soubor()
 
-      Vrací cestu k miniaturnímu náhledu souboru.
+      Vrací náhledový soubor (první podle názvu, shodně s výpisem souborů).
 
       :return: První soubor nebo None, pokud žádný neexistuje.
 

--- a/docs/source/12_zavislosti/python_knihovny.rst
+++ b/docs/source/12_zavislosti/python_knihovny.rst
@@ -308,7 +308,7 @@ Tento soubor je důležitý pro porozumění právním aspektům použitých kni
      - MIT License
      - https://foss.heptapod.net/openpyxl/et_xmlfile
    * - filelock
-     - 3.30.3
+     - 3.31.1
      - MIT
      - https://github.com/tox-dev/py-filelock
    * - freezegun
@@ -416,7 +416,7 @@ Tento soubor je důležitý pro porozumění právním aspektům použitých kni
      - MIT
      - https://github.com/raimon49/pip-licenses
    * - platformdirs
-     - 4.10.0
+     - 4.10.1
      - MIT
      - https://github.com/tox-dev/platformdirs
    * - polib
@@ -564,7 +564,7 @@ Tento soubor je důležitý pro porozumění právním aspektům použitých kni
      - Apache Software License
      - http://www.grantjenks.com/docs/sortedcontainers/
    * - soupsieve
-     - 2.8.4
+     - 2.9
      - MIT
      - https://github.com/facelessuser/soupsieve
    * - sphinx_rtd_theme
@@ -596,7 +596,7 @@ Tento soubor je důležitý pro porozumění právním aspektům použitých kni
      - BSD License
      - http://sphinx-doc.org/
    * - sphinxcontrib-mermaid
-     - 2.0.3
+     - 2.1.0
      - BSD-2-Clause
      - https://github.com/mgaitan/sphinxcontrib-mermaid
    * - sphinxcontrib-qthelp

--- a/webclient/core/models.py
+++ b/webclient/core/models.py
@@ -125,6 +125,37 @@ class SouborVazby(ExportModelOperationsMixin("soubor_vazby"), models.Model):
             return self.samostatny_nalez_souboru
 
 
+def soubor_nazev_razeni_klic(soubor):
+    """
+    Vrátí řadicí klíč souboru podle názvu.
+
+    Při porovnání se tečka chová jako znak ``0``, což zachovává dosavadní pořadí
+    výpisu souborů v detailu záznamu (např. ``foto.jpg`` před ``foto2.jpg``). Používá
+    se pro jednotné určení pořadí souborů i výběr náhledového souboru napříč
+    dokumenty, 3D modely i samostatnými nálezy.
+
+    :param soubor: Soubor, z jehož názvu se klíč sestaví.
+    :return: N-tice použitelná jako ``key`` pro ``sorted`` nebo ``min``.
+    """
+    return (soubor.nazev.replace(".", "0"), soubor.nazev)
+
+
+def prvni_soubor_dle_nazvu(soubory):
+    """
+    Vrátí náhledový soubor jako první soubor seřazený podle názvu.
+
+    Pořadí odpovídá výpisu souborů v detailu (viz :func:`soubor_nazev_razeni_klic`),
+    takže náhled je vždy první soubor v seznamu.
+
+    :param soubory: Iterovatelná kolekce souborů.
+    :return: Soubor s nejnižším řadicím klíčem názvu, nebo None pro prázdný vstup.
+    """
+    soubory = list(soubory)
+    if not soubory:
+        return None
+    return min(soubory, key=soubor_nazev_razeni_klic)
+
+
 class Soubor(ExportModelOperationsMixin("soubor"), models.Model):
     """Model pro soubor. Obsahuje jeho základné data, vazbu na historii a souborovů vazbu."""
 

--- a/webclient/core/templates/core/export_modal.html
+++ b/webclient/core/templates/core/export_modal.html
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="modal" tabindex="-1" role="dialog" id="export-progress-modal">
     <div class="modal-dialog" role="document">
-      <div class="modal-content" style="background-color: white">
+      <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">{% trans "core.templates.core.export-modal.title" %}</h5>
         </div>

--- a/webclient/core/tests/test_soubor_razeni.py
+++ b/webclient/core/tests/test_soubor_razeni.py
@@ -1,0 +1,127 @@
+"""
+Testy sdíleného řazení souborů podle názvu.
+
+Pokrývají :func:`core.models.soubor_nazev_razeni_klic` a
+:func:`core.models.prvni_soubor_dle_nazvu`, které jednotně určují pořadí souborů
+a výběr náhledového souboru napříč dokumenty, 3D modely i samostatnými nálezy.
+"""
+
+from core.models import prvni_soubor_dle_nazvu, soubor_nazev_razeni_klic
+from django.test import SimpleTestCase
+
+
+class _SouborStub:
+    """Odlehčená náhrada za :class:`core.models.Soubor` nesoucí pouze název."""
+
+    def __init__(self, nazev):
+        """
+        Inicializuje stub souboru.
+
+        :param nazev: Název souboru použitý pro řazení.
+        """
+        self.nazev = nazev
+
+    def __repr__(self):
+        """
+        Vrátí čitelnou reprezentaci pro výstup testů.
+
+        :return: Reprezentace obsahující název souboru.
+        """
+        return f"_SouborStub({self.nazev!r})"
+
+
+class SouborNazevRazeniKlicTest(SimpleTestCase):
+    """Testuje řadicí klíč :func:`soubor_nazev_razeni_klic`."""
+
+    def test_klic_nahrazuje_tecku_nulou(self):
+        """Ověří, že klíč porovnává tečku jako znak ``0`` a zachová původní název."""
+        self.assertEqual(soubor_nazev_razeni_klic(_SouborStub("foto.jpg")), ("foto0jpg", "foto.jpg"))
+
+    def test_zaklad_pred_ciselnym_suffixem_bez_pomlcky(self):
+        """``foto.jpg`` se řadí před ``foto2.jpg`` (tečka jako ``0`` je menší než ``2``)."""
+        soubory = [_SouborStub("foto2.jpg"), _SouborStub("foto.jpg")]
+        self.assertEqual([s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)], ["foto.jpg", "foto2.jpg"])
+
+    def test_pomlckovy_suffix_pred_zakladem(self):
+        """``foto-2.jpg`` se řadí před ``foto.jpg`` (pomlčka je menší než ``0``)."""
+        soubory = [_SouborStub("foto.jpg"), _SouborStub("foto-2.jpg")]
+        self.assertEqual([s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)], ["foto-2.jpg", "foto.jpg"])
+
+
+class PrvniSouborDleNazvuTest(SimpleTestCase):
+    """Testuje výběr náhledového souboru :func:`prvni_soubor_dle_nazvu`."""
+
+    def test_prazdny_vstup_vraci_none(self):
+        """Prázdná kolekce vrátí ``None``."""
+        self.assertIsNone(prvni_soubor_dle_nazvu([]))
+
+    def test_vybere_prvni_dle_klice(self):
+        """Vybere soubor s nejnižším řadicím klíčem názvu bez ohledu na vstupní pořadí."""
+        soubory = [_SouborStub("C-3D-x.jpg"), _SouborStub("C-3D-x-b.jpg"), _SouborStub("C-3D-x-a.jpg")]
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C-3D-x-a.jpg")
+
+    def test_vyber_odpovida_serazeni(self):
+        """Vybraný soubor je totožný s prvním prvkem ``sorted`` podle stejného klíče."""
+        soubory = [_SouborStub("b.jpg"), _SouborStub("a-1.jpg"), _SouborStub("a.jpg")]
+        serazene = sorted(soubory, key=soubor_nazev_razeni_klic)
+        self.assertIs(prvni_soubor_dle_nazvu(soubory), serazene[0])
+
+    def test_prijima_generator(self):
+        """Funkce zvládne i neopakovatelný iterátor (generátor)."""
+        soubory = (_SouborStub(n) for n in ["z.jpg", "a.jpg", "m.jpg"])
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "a.jpg")
+
+
+class RealneNazvySouboruTest(SimpleTestCase):
+    """Testuje řazení na reálných názvech souborů používaných v aplikaci."""
+
+    def test_dokument_foto_serie_F(self):
+        """Fotografie dokumentu ``...F01``–``...F03`` se řadí vzestupně a náhled je ``F01``."""
+        soubory = [
+            _SouborStub("C201911202N00047F03.jpg"),
+            _SouborStub("C201911202N00047F01.jpg"),
+            _SouborStub("C201911202N00047F02.jpg"),
+        ]
+        self.assertEqual(
+            [s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)],
+            [
+                "C201911202N00047F01.jpg",
+                "C201911202N00047F02.jpg",
+                "C201911202N00047F03.jpg",
+            ],
+        )
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C201911202N00047F01.jpg")
+
+    def test_foto_serie_zachova_poradi_pri_dvouciferne_nule(self):
+        """Nula doplněné pořadí (``F01``–``F10``) se řadí správně i pro dvojciferný index."""
+        soubory = [
+            _SouborStub("C201911202N00047F10.jpg"),
+            _SouborStub("C201911202N00047F02.jpg"),
+            _SouborStub("C201911202N00047F01.jpg"),
+        ]
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C201911202N00047F01.jpg")
+
+    def test_dokument_pdf_pismenny_suffix(self):
+        """PDF s písmenným suffixem ``A``–``C`` se řadí abecedně a náhled je ``A``."""
+        soubory = [
+            _SouborStub("XCDD000000009B.pdf"),
+            _SouborStub("XCDD000000009A.pdf"),
+            _SouborStub("XCDD000000009C.pdf"),
+        ]
+        self.assertEqual(
+            [s.nazev for s in sorted(soubory, key=soubor_nazev_razeni_klic)],
+            [
+                "XCDD000000009A.pdf",
+                "XCDD000000009B.pdf",
+                "XCDD000000009C.pdf",
+            ],
+        )
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "XCDD000000009A.pdf")
+
+    def test_ruzne_zaklady_nazvu(self):
+        """Soubory s odlišným základem názvu se řadí podle celého názvu."""
+        soubory = [
+            _SouborStub("XCDD000000009A.pdf"),
+            _SouborStub("C201911202N00047F03.jpg"),
+        ]
+        self.assertEqual(prvni_soubor_dle_nazvu(soubory).nazev, "C201911202N00047F03.jpg")

--- a/webclient/core/utils.py
+++ b/webclient/core/utils.py
@@ -1275,13 +1275,11 @@ class SearchTable(ColumnShiftTableBootstrap4):
 
             :return: Vrací hodnotu podle větve zpracování, typicky: výsledek volání ``format_html()``, str.
         """
+        from core.models import prvni_soubor_dle_nazvu
         from pas.models import SamostatnyNalez
 
         record: SamostatnyNalez
-        if record.soubory.soubory.count() > 0:
-            soubor = record.soubory.soubory.first()
-        else:
-            soubor = None
+        soubor = prvni_soubor_dle_nazvu(record.soubory.soubory.all())
         if soubor is not None:
             from core.models import Soubor
 

--- a/webclient/dokument/models.py
+++ b/webclient/dokument/models.py
@@ -22,7 +22,7 @@ from core.constants import (
     ZAPSANI_DOK,
 )
 from core.exceptions import MaximalIdentNumberError, UnexpectedDataRelations
-from core.models import ModelWithMetadata, Soubor, SouborVazby
+from core.models import ModelWithMetadata, Soubor, SouborVazby, prvni_soubor_dle_nazvu
 from django.conf import settings
 from django.contrib.gis.db.models import PointField
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -540,14 +540,11 @@ class Dokument(ExportModelOperationsMixin("dokument"), ModelWithMetadata):
     @property
     def thumbnail_image_file(self) -> Soubor | None:
         """
-        Vrací první soubor jako náhled (seřazeny abecedně).
+        Vrací první soubor jako náhled (seřazeno podle názvu shodně s výpisem souborů).
 
         :return: První seřazený soubor nebo None.
         """
-        if self.soubory.soubory.count() > 0:
-            soubory = [x for x in self.soubory.soubory.all()]
-            soubory = list(sorted(soubory, key=lambda x: x.nazev))
-            return soubory[0]
+        return prvni_soubor_dle_nazvu(self.soubory.soubory.all())
 
     @cached_property
     def large_thumbnail(self):

--- a/webclient/dokument/tables.py
+++ b/webclient/dokument/tables.py
@@ -1,7 +1,7 @@
 import logging
 
 import django_tables2 as tables
-from core.models import Soubor
+from core.models import Soubor, prvni_soubor_dle_nazvu
 from core.utils import SearchTable
 from django.urls import reverse
 from django.utils.html import format_html
@@ -111,10 +111,7 @@ class Model3DTable(SearchTable):
         :param record: Záznam s daty modelu 3D.
         :return: HTML řetězec s náhledem nebo prázdný řetězec.
         """
-        if len(record.soubory.soubory.all()) > 0:
-            soubor = record.soubory.soubory.first()
-        else:
-            soubor = None
+        soubor = prvni_soubor_dle_nazvu(record.soubory.soubory.all())
         if soubor is not None:
             soubor: Soubor
             thumbnail_url = reverse(
@@ -125,8 +122,8 @@ class Model3DTable(SearchTable):
                     soubor.id,
                 ),
             )
-            soubor_url = reverse(
-                "core:download_file",
+            thumbnail_large_url = reverse(
+                "core:download_thumbnail_large",
                 args=(
                     "model3d",
                     record.ident_cely,
@@ -137,7 +134,7 @@ class Model3DTable(SearchTable):
                 '<img src="{}" class="image-nahled" data-bs-toggle="modal" data-bs-target="#soubor-modal" loading="lazy" data-fullsrc="{}" '
                 'style="opacity:0" onload="this.style.opacity=100">',
                 thumbnail_url,
-                soubor_url,
+                thumbnail_large_url,
             )
         return ""
 
@@ -262,8 +259,8 @@ class DokumentTable(SearchTable):
         :param record: Záznam s daty modelu 3D.
         :return: HTML řetězec s náhledem nebo prázdný řetězec.
         """
-        if hasattr(record.soubory, "first_soubor") and len(record.soubory.first_soubor) > 0:
-            soubor = record.soubory.first_soubor[0]
+        if hasattr(record.soubory, "soubory_nahled"):
+            soubor = prvni_soubor_dle_nazvu(record.soubory.soubory_nahled)
         else:
             soubor = None
         if soubor is not None:

--- a/webclient/dokument/views.py
+++ b/webclient/dokument/views.py
@@ -2753,34 +2753,44 @@ def pripojit(request, ident_zaznam, proj_ident_cely, typ):
         if len(dokument_ids) > 0:
             fedora_transaction = zaznam.create_transaction(request.user)
             try:
-                for dokument_id in dokument_ids:
-                    dokument = get_object_or_404(Dokument, id=dokument_id)
-                    dokument.active_transaction = fedora_transaction
-                    relace = casti_zaznamu.filter(dokument__id=dokument_id)
-                    if not relace.exists():
-                        dc_ident = get_cast_dokumentu_ident(dokument)
-                        if isinstance(zaznam, ArcheologickyZaznam):
-                            dc = DokumentCast(
-                                archeologicky_zaznam=zaznam,
-                                dokument=dokument,
-                                ident_cely=dc_ident,
+                # Deterministické pořadí zamykání – dvě souběžné dávky sdílející dokumenty
+                # by při opačném pořadí jinak mohly na select_for_update uváznout (deadlock).
+                for dokument_id in sorted(dokument_ids):
+                    with transaction.atomic():
+                        # Zámek řádku dokumentu serializuje souběžné připojení téhož dokumentu –
+                        # jinak oba requesty spočítají v get_cast_dokumentu_ident stejné pořadové
+                        # číslo části a druhý insert spadne na unique constraint (IntegrityError, #4141).
+                        dokument = get_object_or_404(Dokument.objects.select_for_update(), id=dokument_id)
+                        dokument.active_transaction = fedora_transaction
+                        relace = casti_zaznamu.filter(dokument__id=dokument_id)
+                        if not relace.exists():
+                            dc_ident = get_cast_dokumentu_ident(dokument)
+                            if isinstance(zaznam, ArcheologickyZaznam):
+                                dc = DokumentCast(
+                                    archeologicky_zaznam=zaznam,
+                                    dokument=dokument,
+                                    ident_cely=dc_ident,
+                                )
+                            else:
+                                dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
+                            dc.active_transaction = fedora_transaction
+                            dc.save()
+                            dokument.save()
+                            logger.debug(
+                                "dokument.views.pripojit.pripojit",
+                                extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
+                            )
+                            messages.add_message(
+                                request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
                             )
                         else:
-                            dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
-                        dc.active_transaction = fedora_transaction
-                        dc.save()
-                        dokument.save()
-                        logger.debug(
-                            "dokument.views.pripojit.pripojit",
-                            extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
-                        )
-                        messages.add_message(
-                            request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
-                        )
-                    else:
-                        messages.add_message(
-                            request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
-                        )
+                            messages.add_message(
+                                request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
+                            )
+            except FedoraError:
+                # Souběžná úprava téhož záznamu (Fedora 409) apod. – necháme probublat do
+                # dekorátoru handle_fedora_error, který vrátí čistou odpověď a zrolluje transakci.
+                raise
             except Exception as err:
                 logger.error("dokument.views.pripojit.error", extra={"error": err, "ident_cely": dokument.ident_cely})
                 transaction.set_rollback(True)

--- a/webclient/dokument/views.py
+++ b/webclient/dokument/views.py
@@ -2754,33 +2754,41 @@ def pripojit(request, ident_zaznam, proj_ident_cely, typ):
             fedora_transaction = zaznam.create_transaction(request.user)
             try:
                 for dokument_id in dokument_ids:
-                    dokument = get_object_or_404(Dokument, id=dokument_id)
-                    dokument.active_transaction = fedora_transaction
-                    relace = casti_zaznamu.filter(dokument__id=dokument_id)
-                    if not relace.exists():
-                        dc_ident = get_cast_dokumentu_ident(dokument)
-                        if isinstance(zaznam, ArcheologickyZaznam):
-                            dc = DokumentCast(
-                                archeologicky_zaznam=zaznam,
-                                dokument=dokument,
-                                ident_cely=dc_ident,
+                    with transaction.atomic():
+                        # Zámek řádku dokumentu serializuje souběžné připojení téhož dokumentu –
+                        # jinak oba requesty spočítají v get_cast_dokumentu_ident stejné pořadové
+                        # číslo části a druhý insert spadne na unique constraint (IntegrityError, #4141).
+                        dokument = get_object_or_404(Dokument.objects.select_for_update(), id=dokument_id)
+                        dokument.active_transaction = fedora_transaction
+                        relace = casti_zaznamu.filter(dokument__id=dokument_id)
+                        if not relace.exists():
+                            dc_ident = get_cast_dokumentu_ident(dokument)
+                            if isinstance(zaznam, ArcheologickyZaznam):
+                                dc = DokumentCast(
+                                    archeologicky_zaznam=zaznam,
+                                    dokument=dokument,
+                                    ident_cely=dc_ident,
+                                )
+                            else:
+                                dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
+                            dc.active_transaction = fedora_transaction
+                            dc.save()
+                            dokument.save()
+                            logger.debug(
+                                "dokument.views.pripojit.pripojit",
+                                extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
+                            )
+                            messages.add_message(
+                                request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
                             )
                         else:
-                            dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
-                        dc.active_transaction = fedora_transaction
-                        dc.save()
-                        dokument.save()
-                        logger.debug(
-                            "dokument.views.pripojit.pripojit",
-                            extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
-                        )
-                        messages.add_message(
-                            request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
-                        )
-                    else:
-                        messages.add_message(
-                            request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
-                        )
+                            messages.add_message(
+                                request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
+                            )
+            except FedoraError:
+                # Souběžná úprava téhož záznamu (Fedora 409) apod. – necháme probublat do
+                # dekorátoru handle_fedora_error, který vrátí čistou odpověď a zrolluje transakci.
+                raise
             except Exception as err:
                 logger.error("dokument.views.pripojit.error", extra={"error": err, "ident_cely": dokument.ident_cely})
                 transaction.set_rollback(True)

--- a/webclient/dokument/views.py
+++ b/webclient/dokument/views.py
@@ -2754,41 +2754,33 @@ def pripojit(request, ident_zaznam, proj_ident_cely, typ):
             fedora_transaction = zaznam.create_transaction(request.user)
             try:
                 for dokument_id in dokument_ids:
-                    with transaction.atomic():
-                        # Zámek řádku dokumentu serializuje souběžné připojení téhož dokumentu –
-                        # jinak oba requesty spočítají v get_cast_dokumentu_ident stejné pořadové
-                        # číslo části a druhý insert spadne na unique constraint (IntegrityError, #4141).
-                        dokument = get_object_or_404(Dokument.objects.select_for_update(), id=dokument_id)
-                        dokument.active_transaction = fedora_transaction
-                        relace = casti_zaznamu.filter(dokument__id=dokument_id)
-                        if not relace.exists():
-                            dc_ident = get_cast_dokumentu_ident(dokument)
-                            if isinstance(zaznam, ArcheologickyZaznam):
-                                dc = DokumentCast(
-                                    archeologicky_zaznam=zaznam,
-                                    dokument=dokument,
-                                    ident_cely=dc_ident,
-                                )
-                            else:
-                                dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
-                            dc.active_transaction = fedora_transaction
-                            dc.save()
-                            dokument.save()
-                            logger.debug(
-                                "dokument.views.pripojit.pripojit",
-                                extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
-                            )
-                            messages.add_message(
-                                request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
+                    dokument = get_object_or_404(Dokument, id=dokument_id)
+                    dokument.active_transaction = fedora_transaction
+                    relace = casti_zaznamu.filter(dokument__id=dokument_id)
+                    if not relace.exists():
+                        dc_ident = get_cast_dokumentu_ident(dokument)
+                        if isinstance(zaznam, ArcheologickyZaznam):
+                            dc = DokumentCast(
+                                archeologicky_zaznam=zaznam,
+                                dokument=dokument,
+                                ident_cely=dc_ident,
                             )
                         else:
-                            messages.add_message(
-                                request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
-                            )
-            except FedoraError:
-                # Souběžná úprava téhož záznamu (Fedora 409) apod. – necháme probublat do
-                # dekorátoru handle_fedora_error, který vrátí čistou odpověď a zrolluje transakci.
-                raise
+                            dc = DokumentCast(projekt=zaznam, dokument=dokument, ident_cely=dc_ident)
+                        dc.active_transaction = fedora_transaction
+                        dc.save()
+                        dokument.save()
+                        logger.debug(
+                            "dokument.views.pripojit.pripojit",
+                            extra={"value": debug_name, "zaznam": ident_zaznam, "ident_cely": dokument.ident_cely},
+                        )
+                        messages.add_message(
+                            request, messages.SUCCESS, f"{dokument.ident_cely} {DOKUMENT_USPESNE_PRIPOJEN}"
+                        )
+                    else:
+                        messages.add_message(
+                            request, messages.ERROR, f"{dokument.ident_cely} {DOKUMENT_JIZ_BYL_PRIPOJEN}"
+                        )
             except Exception as err:
                 logger.error("dokument.views.pripojit.error", extra={"error": err, "ident_cely": dokument.ident_cely})
                 transaction.set_rollback(True)

--- a/webclient/dokument/views.py
+++ b/webclient/dokument/views.py
@@ -55,7 +55,7 @@ from core.message_constants import (
     ZAZNAM_USPESNE_VYTVOREN,
 )
 from core.models import Permissions as p
-from core.models import Soubor, check_permissions
+from core.models import Soubor, check_permissions, soubor_nazev_razeni_klic
 from core.repository_connector import FedoraError, FedoraRepositoryConnector, FedoraTransaction
 from core.utils import TwoQueryPaginator, get_3d_from_envelope
 from core.views import PermissionFilterMixin, SearchListView, check_stav_changed
@@ -67,7 +67,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import IntegrityError, transaction
-from django.db.models import OuterRef, Prefetch, Q, Subquery
+from django.db.models import Prefetch, Q
 from django.forms import inlineformset_factory
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -244,7 +244,7 @@ def detail_model_3D(request, ident_cely):
     context["show"] = show
     context["global_map_can_edit"] = False
     if dokument.soubory:
-        context["soubory"] = sorted(dokument.soubory.soubory.all(), key=lambda x: (x.nazev.replace(".", "0"), x.nazev))
+        context["soubory"] = sorted(dokument.soubory.soubory.all(), key=soubor_nazev_razeni_klic)
     else:
         context["soubory"] = None
     return render(request, "dokument/detail_model_3D.html", context)
@@ -453,7 +453,6 @@ class DokumentListView(SearchListView):
         sort_params = [self.rename_field_for_ordering(x) for x in sort_params]
         qs = super().get_queryset()
         qs = qs.order_by(*sort_params)
-        subqry = Subquery(Soubor.objects.filter(vazba=OuterRef("vazba")).values_list("id", flat=True)[:1])
         qs = qs.exclude(typ_dokumentu__id__in=MODEL_3D_DOKUMENT_TYPES)
         qs = (
             qs.select_related(
@@ -471,8 +470,8 @@ class DokumentListView(SearchListView):
             .prefetch_related(
                 Prefetch(
                     "soubory__soubory",
-                    queryset=Soubor.objects.filter(id__in=subqry),
-                    to_attr="first_soubor",
+                    queryset=Soubor.objects.only("id", "nazev", "vazba"),
+                    to_attr="soubory_nahled",
                 ),
                 Prefetch(
                     "autori",
@@ -641,9 +640,7 @@ class RelatedContext(LoginRequiredMixin, TemplateView):
         context["show"] = show
 
         if dokument.soubory:
-            context["soubory"] = sorted(
-                dokument.soubory.soubory.all(), key=lambda x: (x.nazev.replace(".", "0"), x.nazev)
-            )
+            context["soubory"] = sorted(dokument.soubory.soubory.all(), key=soubor_nazev_razeni_klic)
         else:
             context["soubory"] = None
 

--- a/webclient/pas/models.py
+++ b/webclient/pas/models.py
@@ -16,7 +16,7 @@ from core.constants import (
     VRACENI_SN,
     ZAPSANI_SN,
 )
-from core.models import ModelWithMetadata, SouborVazby
+from core.models import ModelWithMetadata, SouborVazby, prvni_soubor_dle_nazvu
 from django.conf import settings
 from django.contrib.gis.db import models as pgmodels
 from django.db import models
@@ -336,15 +336,12 @@ class SamostatnyNalez(ExportModelOperationsMixin("samostatny_nalez"), ModelWithM
     @property
     def nahled_soubor(self):
         """
-        Vrací cestu k miniaturnímu náhledu souboru.
+        Vrací náhledový soubor (první podle názvu, shodně s výpisem souborů).
 
         :return: První soubor nebo None, pokud žádný neexistuje.
 
         """
-        if self.soubory.soubory.count() > 0:
-            return self.soubory.soubory.first()
-        else:
-            return None
+        return prvni_soubor_dle_nazvu(self.soubory.soubory.all())
 
     @cached_property
     def large_thumbnail(self):

--- a/webclient/pas/views.py
+++ b/webclient/pas/views.py
@@ -45,7 +45,7 @@ from core.message_constants import (
     ZAZNAM_USPESNE_VYTVOREN,
 )
 from core.models import Permissions as p
-from core.models import check_permissions
+from core.models import check_permissions, soubor_nazev_razeni_klic
 from core.repository_connector import FedoraError, FedoraRepositoryConnector, FedoraTransaction
 from core.utils import TwoQueryPaginator, get_cadastre_from_point, get_cadastre_from_point_with_geometry
 from core.views import PermissionFilterMixin, SearchListView, check_stav_changed
@@ -104,7 +104,7 @@ def get_detail_context(sn, request):
     context["history_dates"] = get_history_dates(sn.historie, request.user)
     context["show"] = get_detail_template_shows(sn, request.user)
     if sn.soubory:
-        context["soubory"] = sorted(sn.soubory.soubory.all(), key=lambda x: (x.nazev.replace(".", "0"), x.nazev))
+        context["soubory"] = sorted(sn.soubory.soubory.all(), key=soubor_nazev_razeni_klic)
     else:
         context["soubory"] = None
     context["app"] = "pas"

--- a/webclient/static/js/html-to-rtf-browser.js
+++ b/webclient/static/js/html-to-rtf-browser.js
@@ -8946,6 +8946,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (attributes.class && attributes.class.includes('soubor')) {
                         tagName = tagName + '.soubor';
                     }
+                    if (attributes.class && attributes.class.includes('dok_zaznam') && attributes.class.includes('content')) {
+                        tagName = tagName + '.dok_zaznam';
+                    }
                     allowedTag = this.getAllowedTag(tagName);
 
                     if (allowedTag) {
@@ -9004,6 +9007,12 @@ document.addEventListener('DOMContentLoaded', function () {
                     opening: 'div',
                     openingRtf: '',
                     closing: '/div',
+                    closingRtf: ''
+                },
+                {
+                    opening: 'div.dok_zaznam',
+                    openingRtf: '\\\'20',
+                    closing: '/div.dok_zaznam',
                     closingRtf: ''
                 },
                 {
@@ -9242,9 +9251,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 },
                 {
                     opening: 'div.sub-header',
-                    openingRtf: '{\\pard{\\b',
+                    openingRtf: '{\\pard',
                     closing: '/div.sub-header',
-                    closingRtf: '}\\sb70\\par}'
+                    closingRtf: '\\sb70\\par}'
                 },
             ];
 

--- a/webclient/static/js/vypis-report.js
+++ b/webclient/static/js/vypis-report.js
@@ -17,6 +17,7 @@
 
         label.textContent = simpleViewEnabled ? fullLabel : simpleLabel;
         toggle.setAttribute('aria-label', simpleViewEnabled ? fullLabel : simpleLabel);
+        toggle.setAttribute('data-bs-original-title', simpleViewEnabled ? fullLabel : simpleLabel);
         toggle.checked = simpleViewEnabled;
 
         document.querySelectorAll('#app-wrapper .not-simple').forEach((section) => {

--- a/webclient/static/scss/_app-theme-dark.scss
+++ b/webclient/static/scss/_app-theme-dark.scss
@@ -23,17 +23,6 @@ body.app-dark-theme {
     color: $body-text-dark;
     background-color: $body-bg-dark;
 
-    @include setEntityTransakceColor($dark-entities);
-
-    .app-entity-cards {
-        .col {
-
-            .app-card-entity {
-                @include setEntityColor("card", $dark-entities, null);
-            }
-        }
-    }
-
     // Sidebar
     .app-sidebar-wrapper {
         background-color: $app-sidebar-bg-dark;
@@ -143,7 +132,91 @@ body.app-dark-theme {
     }
 
     #app-page-wrapper .container-fluid.app-content-wrapper {
-        @include setEntityElementsColor($dark-entities);
+        @each $entity, $color in $dark-entities {
+            .app-entity-#{$entity} {
+                .app-table-list-wrapper {
+                    .table {
+                        thead {
+                            position: sticky;
+                            top: 0;
+                            --bs-table-bg: #{$color} !important;
+
+                            a {
+                                color: $white;
+                            }
+
+                            .white {
+                                color: $white;
+                            }
+                        }
+
+                        tbody {
+                            a {
+                                color: $color;
+                            }
+
+                            button {
+                                color: $color;
+                            }
+
+                            td {
+                                vertical-align: middle;
+                            }
+                        }
+                    }
+                }
+
+                // pagination
+                .pagination {
+                    .page-item {
+                        &.active {
+                            .page-link {
+                                background-color: $color;
+                                color: $white;
+                                display: flex;
+                                border: 1px solid #dee2e6;
+                            }
+                        }
+
+                        .page-link {
+                            color: $color;
+                            display: flex;
+                        }
+                    }
+                }
+            }
+
+            .app-card-#{$entity} {
+                table {
+                    tr {
+                        td {
+                            &.app-ident-cely {
+                                color: $color !important;
+
+                                .material-icons {
+                                    color: $color;
+                                }
+
+                                a {
+                                    color: $color;
+                                }
+                            }
+
+                            &.app-cell-badge {
+                                padding-left: 0;
+                            }
+
+                            .badge {
+                                background-color: $color !important;
+                                color: $white;
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
         background-color: $body-bg-dark;
 
         .app-toolbar {
@@ -167,6 +240,8 @@ body.app-dark-theme {
             }
         }
 
+
+
         .app-right .btn-group .btn {
             color: $body-text-dark;
         }
@@ -181,6 +256,10 @@ body.app-dark-theme {
 
         .uiElement.label {
             color: $gray-100-dark;
+        }
+
+        .leaflet-draw-actions a {
+            color: $body-text-dark !important;
         }
     }
 
@@ -221,6 +300,10 @@ body.app-dark-theme {
 
         .card-body {
             color: $body-text-dark;
+
+            .material-icons {
+                color: $body-text-dark;
+            }
         }
     }
 

--- a/webclient/static/scss/_app-vypis.scss
+++ b/webclient/static/scss/_app-vypis.scss
@@ -12,7 +12,15 @@
   .app-content-wrapper {
 
     .simple-view-label {
-      word-break: break-word;
+      white-space: normal;
+      word-break: normal;
+      overflow-wrap: break-word;
+    }
+
+    @media (max-width: 649.98px) {
+      .simple-view-label {
+        display: none;
+      }
     }
 
     button {

--- a/webclient/vypis/config.py
+++ b/webclient/vypis/config.py
@@ -369,7 +369,7 @@ DOKUMENTY_CONFIG = {
             ),
             "template": SimpleSectionTemplateName("vypis/simple_section_with_name.html"),
             "dok_zaznam": ChooseField(
-                _("vypis.dokumenty.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"]
+                _("vypis.dokumenty.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"], "dok_zaznam"
             ),
             "komponenty": SubSectionField(KOMPONENTY_DOKU_CONFIG),
             "neident_akce": NeidentAkceSubSectionField(NEIDENT_AKCE_CONFIG),
@@ -921,7 +921,7 @@ MODEL_CONFIG = {
             ),
             "template": SimpleSectionTemplateName("vypis/simple_section_with_name.html"),
             "dok_zaznam": ChooseField(
-                _("vypis.model3d.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"]
+                _("vypis.model3d.dokument_casti.dok_zaznam.label"), ["archeologicky_zaznam", "projekt"], "dok_zaznam"
             ),
             "komponenty": SubSectionField(KOMPONENTY_DOKU_CONFIG),
         },

--- a/webclient/vypis/fields.py
+++ b/webclient/vypis/fields.py
@@ -993,7 +993,7 @@ class KomponentaRepeatableSectionNameWithAccessor(RepeatableSectionNameWithAcces
         if aktivity:
             third_part = f" ({'; '.join([str(a) for a in aktivity])})"
         return format_html(
-            "<span class='ps-0'>{} {} - {}{} - {}{}</span>",
+            "<span class='ps-0'>{}&nbsp;{}&nbsp;-&nbsp;{}{}&nbsp;-&nbsp;{}{}</span>",
             self.name,
             getattr(instance, self.accessor[0]),
             obdobi,

--- a/webclient/vypis/templates/vypis/simple_section_with_name.html
+++ b/webclient/vypis/templates/vypis/simple_section_with_name.html
@@ -13,7 +13,7 @@
             {% elif section != "section_name" %}
                 <div class="row vypis-field-row {{ field.css_class }}">
                 <div class="label"><strong>{{field.label}}:</strong></div>
-                <div class="content">{{ field.value }}</div>
+                <div class="content {{ field.css_class }}">{{ field.value }}</div>
             </div>
             {% endif %}
         </div>

--- a/webclient/vypis/templates/vypis/vypis.html
+++ b/webclient/vypis/templates/vypis/vypis.html
@@ -25,16 +25,21 @@
   {% endif %}
 <div>
     <div class="row" id="title_row">
-        <div class="col-8">
+        <div class="col-7">
             <h1>{{title}}</h1>
         </div>
-        <div class="col-4 d-print-none align-self-center no-export">
+        <div class="col-2"></div>
+        <div class="col-3 d-print-none align-self-center no-export">
             <div class="d-flex align-items-center justify-content-end gap-2">
                 <div class="form-check-reverse form-switch mb-0">
                     <input class="form-check-input" type="checkbox" id="simple-view-toggle" onchange="toggleSimpleView()"
                         aria-label="{% trans 'vypis.templates.vypis.simple_view.label' %}"
                         data-simple-label="{% trans 'vypis.templates.vypis.simple_view.label' %}"
-                        data-full-label="{% trans 'vypis.templates.vypis.full_view.label' %}">
+                        data-full-label="{% trans 'vypis.templates.vypis.full_view.label' %}"
+                        title="{% trans 'vypis.templates.vypis.simple_view.label' %}"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        data-bs-trigger="hover">
                     <label class="form-check-label simple-view-label" for="simple-view-toggle" id="simple-view-toggle-label">
                         {% trans 'vypis.templates.vypis.simple_view.label' %}
                     </label>
@@ -55,4 +60,15 @@
 </div>
 {% endblock %}
 
-{% block script %}{% endblock %}
+{% block script %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const tooltipTriggerList = [].slice.call(
+        document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    );
+    tooltipTriggerList.forEach(function (el) {
+        new bootstrap.Tooltip(el);
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
<!-- aiscr-review-pr:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4155

| Field | Value |
| --- | --- |
| Title | v1.4.0-rc1 |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4155 |
| Author | motyc |
| Base ← head | main ← test |
| Head SHA | 7b95c6c9f579c06a8c8a45aef2b902ff65a95bdc |
| Size | +382 / −89 across 20 files (9 commits) |
| State | OPEN |
| Marked AIS CR review baseline | none |
| Prior PR summary | none |

## Purpose and scope

Release-candidate merge of `test` into `main` for **v1.4.0-rc1**. The PR body is empty; the change set is a batch of already-merged or stacked fixes on `test`, plus a final merge of `main` into `test`.

Primary themes in the diff:

1. **Unified file-name sorting for thumbnails** — shared helpers so document / 3D / PAS thumbnail selection matches the detail-page file list order (including the `foto.jpg` before `foto2.jpg` rule).
2. **Concurrent document attach** — serialize attaching the same document from two actions so `get_cast_dokumentu_ident` cannot mint a duplicate cast ident (`IntegrityError`, related to #4141 / #4153).
3. **Dark-mode / UI polish (bug/2322)** — entity colors limited to tables, export modal background, map/icon colors, and related SCSS.
4. **Výpis (report) UX** — RTF export class handling for `dok_zaznam`, simple-view toggle tooltip, responsive label layout, and non-breaking spaces in field labels.

Out of scope for this PR as presented: no version-bump file or release notes in the diff; no new product feature beyond the fixes above.

## Change map by area

| Area | Paths (representative) | What changed |
| --- | --- | --- |
| Shared file ordering | `webclient/core/models.py`, `webclient/core/tests/test_soubor_razeni.py`, docs under `docs/source/.../core|dokument|pas/models.rst` | New `soubor_nazev_razeni_klic` / `prvni_soubor_dle_nazvu`; unit tests; Sphinx docs |
| Consumers of ordering | `dokument/models.py`, `dokument/tables.py`, `pas/models.py`, `pas/views.py`, `core/utils.py`, `dokument/views.py` | Thumbnail / list sorting switched to the shared helpers |
| Concurrent attach | `webclient/dokument/views.py` (`pripojit`) | Sorted lock order + `select_for_update` + per-document `transaction.atomic` |
| Dark theme / export UI | `_app-theme-dark.scss`, `core/templates/core/export_modal.html` | Table-scoped entity colors; remove hard-coded white modal background |
| Výpis / RTF | `vypis/*`, `static/js/html-to-rtf-browser.js`, `vypis-report.js`, `_app-vypis.scss` | CSS class plumbing, tooltip sync, layout tweaks |

Commit lineage on the PR (newest last): merge #4151 → thumbnail ordering #4152 → concurrent-attach attempts/reverts → dark-mode #4154 → concurrent-attach #4153 → merge `main` into `test`.

## Change walkthrough

The release candidate is a **integration PR**: several independent fixes land on `test` and are promoted together to `main`.

**Thumbnail ordering.** Detail views already sorted files with a special key where `.` behaves like `0` so `foto.jpg` sorts before `foto2.jpg`. Thumbnail properties previously used ORM `.first()` (or equivalent), which did not guarantee the same order. The shared helpers centralize that key and `min(...)` selection; tables and PAS utilities call the same helper. New `SimpleTestCase` coverage in `test_soubor_razeni.py` locks the ordering contract without hitting the database.

**Concurrent document attach.** In `dokument.views.pripojit`, two parallel requests attaching the same document could both compute the next `DokumentCast.ident_cely` and collide on the unique constraint. The fix locks each `Dokument` row (`select_for_update`), processes document IDs in sorted order to avoid deadlocks across overlapping batches, and wraps each attach in its own atomic block while still using the outer Fedora transaction for repository bookkeeping.

**UI / výpis.** Dark-theme entity coloring is narrowed to table list wrappers (and related map/icon fixes from #4154). Export modal drops an inline white background so theme CSS can apply. Výpis changes thread a `dok_zaznam` CSS class into templates and RTF allow-lists, keep Bootstrap tooltips in sync when toggling simple view, and adjust column/label wrapping for smaller viewports.

```mermaid
flowchart TD
  testBranch["test branch batch"] --> thumb["#4152 shared soubor ordering + tests"]
  testBranch --> dark["#4154 dark-mode / export / map polish"]
  testBranch --> attach["#4153 concurrent dokument attach locks"]
  testBranch --> mergeMain["merge main into test"]
  thumb --> rc["PR #4155 v1.4.0-rc1"]
  dark --> rc
  attach --> rc
  mergeMain --> rc
  rc --> main["merge to main"]
```

## Attention hints (summary only)

- Treat this as a **multi-theme RC**, not a single-feature PR; review each theme on its own risk surface (locking, ordering regressions, CSS regressions).
- Concurrent-attach history on the branch includes **apply → revert → re-apply** commits before the final #4153 land; the net diff in `pripojit` is what matters for review.
- Thumbnail ordering changes affect **documents, 3D models, and PAS** through one helper — regressions would show up as “wrong” thumbnails vs detail file lists.
- Dark-theme SCSS is broad; check that entity colors still appear where intended outside the narrowed table scope.
- No marked AIS CR review baseline yet; code-owner review from `jhavrlant` is requested on GitHub.

## Validation / test surfaces visible in the PR

**Visible in the PR**

- New unit tests: `webclient/core/tests/test_soubor_razeni.py` (ordering / thumbnail helper behaviour).
- Docs updates describing the shared ordering helpers and thumbnail properties.
- CI checks observed at summary time: CodeQL / Analyze (actions, javascript, python), GitGuardian, and pre-commit **passed**; Docker Scout security report was still **pending**.

**Not executed in this summary-only review session**

- No local pytest / Django test run against `aiscr-webamcr`.
- No manual UI checks (dark mode, export modal, výpis RTF, concurrent attach reproduction).
- Formal diff findings review was not run (summary-only request).

## Lineage

- First AIS CR summary round for this PR; no prior marked summary comment or description block.
- No marked `<!-- aiscr-review-pr:v1 -->` formal review baseline.
- Auxiliary / vendor reviews: none gathered.
- Open inline threads: none.
- PR description at gather time: empty.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
