### PR TITLE
bug/2322 oprava pagination

### DIFF
--- a/webclient/static/scss/_app-theme-dark.scss
+++ b/webclient/static/scss/_app-theme-dark.scss
@@ -171,7 +171,6 @@ body.app-dark-theme {
                     .page-item {
                         &.active {
                             .page-link {
-                                background-color: $color;
                                 color: $white;
                                 display: flex;
                                 border: 1px solid #dee2e6;


### PR DESCRIPTION
<!-- aiscr-pr-review:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4157

| Field | Value |
| --- | --- |
| Title | bug/2322 oprava pagination |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4157 |
| Author | @jnihnat |
| Base ← head | `test` ← `bug/2322-oprava-pagination` |
| Head SHA | `aab208ab6974abca5673011bcd76474fb915b908` |
| Size | +0 / −1 across 1 file |
| State | OPEN |
| Marked AIS CR review baseline | none (first marked review round) |
| Prior PR summary | none |

## Purpose and scope

Follow-up for [#2322](https://github.com/ARUP-CAS/aiscr-webamcr/issues/2322) after the [v1.4.0-rc1 lister note](https://github.com/ARUP-CAS/aiscr-webamcr/issues/2322#issuecomment-5024820600): the active page chip on the right was painted with `$dark-entities` fill. This PR removes that dark-theme `background-color: $color` so the marked box keeps the light-theme active background from `setEntityElementsColor()` (via `_app-layout.scss` / `_app-mixins.scss`). Entity-colored link text on inactive pages stays as-is. One-line SCSS change only.

## Change map by area

| Area | Files | What changed |
| --- | --- | --- |
| Dark theme pagination | `webclient/static/scss/_app-theme-dark.scss` | Dropped `background-color: $color` from `.app-entity-* .pagination .page-item.active .page-link`; left `color: $white`, `display: flex`, and `border: 1px solid #dee2e6`. |

## Change walkthrough

Dark mode’s `$dark-entities` `@each` no longer sets an active-page fill. The matching light-theme mixin rule still supplies `background-color` for `.page-item.active .page-link`, which is the intended marked-box treatment. Inactive page links keep `color: $color` from the dark `@each` (text-only accent).

```mermaid
flowchart TD
  feedback["rc1: active chip too strong in dark entities"]
  pr["remove dark active background-color"]
  lightBg["light mixin background remains on marked box"]
  textOk["inactive page text keeps entity color"]
  feedback --> pr
  pr --> lightBg
  pr --> textOk
```

## Attention hints (summary only)

- Cascade to the light-theme active background is intentional, not an accidental leak.
- Active chip still uses `color: $white` and light-theme gray border `#dee2e6`.
- Branch name uses `bug/…` rather than CONTRIBUTING `bugfix/…`; not a functional concern.

## Validation / test surfaces visible in the PR

- Visible in the PR: pre-commit, CodeQL, Analyze (actions/javascript/python), and GitGuardian reported success on the head SHA.
- Not evidenced in the PR: compiled CSS check, screenshot, or browser dark-mode walkthrough of list pagination.
- Executed during this review session so far: `gh pr view` / `gather` / `gh pr diff` / head SCSS inspection, issue-comment + screenshot review, and Bugbot-assisted analysis (no local SCSS compile or UI run).

## Lineage

No prior marked AIS CR review (`<!-- aiscr-pr-review:v1 -->`). No auxiliary GitHub reviews or open inline threads. Related merged dark-mode work: [#4069](https://github.com/ARUP-CAS/aiscr-webamcr/pull/4069), [#4154](https://github.com/ARUP-CAS/aiscr-webamcr/pull/4154). Product intent clarified from [#2322 comment](https://github.com/ARUP-CAS/aiscr-webamcr/issues/2322#issuecomment-5024820600) plus reviewer direction that the light-theme marked-box background should remain.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
