### PR TITLE
bug/3983-oprava seznamu a compressu

### DIFF
--- a/webclient/static/js/html-to-rtf-browser.js
+++ b/webclient/static/js/html-to-rtf-browser.js
@@ -9071,7 +9071,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 },
                 {
                     opening: 'li',
-                    openingRtf: '{\\pnlvlblt\\b\\\'b7}',
+                    openingRtf: '',
                     closing: '/li',
                     closingRtf: '\\par'
                 },

--- a/webclient/static/scss/_app-vypis.scss
+++ b/webclient/static/scss/_app-vypis.scss
@@ -19,7 +19,7 @@
 
     @media (max-width: 649.98px) {
       .simple-view-label {
-        display: none;
+        display: none !important;
       }
     }
 

--- a/webclient/vypis/templates/vypis/vypis.html
+++ b/webclient/vypis/templates/vypis/vypis.html
@@ -1,11 +1,15 @@
 {% extends "base.html" %}
 {% load template_filters %}
 {% load template_tags %}
+{% load compress %}
 {% load i18n %}
 {% load static %}
 
 {% block head %}
 {{ block.super }}
+{% compress css %}
+    <link type="text/x-scss" href="{% static 'theme.scss' %}" rel="stylesheet" media="print">
+{% endcompress %}
 <script src="{% static 'js/html-to-rtf-browser.js' %}"></script>
 <script src="{% static 'js/vypis-report.js' %}"></script>
 {% endblock %}

--- a/webclient/vypis/templates/vypis/vypis.html
+++ b/webclient/vypis/templates/vypis/vypis.html
@@ -2,14 +2,10 @@
 {% load template_filters %}
 {% load template_tags %}
 {% load i18n %}
-{% load compress %}
 {% load static %}
 
 {% block head %}
 {{ block.super }}
-{% compress css %}
-    <link type="text/x-scss" href="{% static 'theme.scss' %}" rel="stylesheet" media="print">
-{% endcompress %}
 <script src="{% static 'js/html-to-rtf-browser.js' %}"></script>
 <script src="{% static 'js/vypis-report.js' %}"></script>
 {% endblock %}

--- a/webclient/vypis/templates/vypis/vypis_list.html
+++ b/webclient/vypis/templates/vypis/vypis_list.html
@@ -1,11 +1,15 @@
 {% extends "base.html" %}
 {% load template_filters %}
 {% load template_tags %}
+{% load compress %}
 {% load i18n %}
 {% load static %}
 
 {% block head %}
 {{ block.super }}
+{% compress css %}
+    <link type="text/x-scss" href="{% static 'theme.scss' %}" rel="stylesheet" media="print">
+{% endcompress %}
 <script src="{% static 'js/html-to-rtf-browser.js' %}"></script>
 <script src="{% static 'js/vypis-report.js' %}"></script>
 {% endblock %}

--- a/webclient/vypis/templates/vypis/vypis_list.html
+++ b/webclient/vypis/templates/vypis/vypis_list.html
@@ -29,8 +29,8 @@
     </div>
     <div class="col-3 d-print-none align-self-center no-export">
         <div class="float-end d-flex align-items-center gap-2">
-            <div class="form-check form-switch form-check-reverse mb-0">
-                <label class="form-check-label" for="simple-view-toggle" id="simple-view-toggle-label">
+            <div class="form-switch form-check-reverse mb-0">
+                <label class="form-check-label simple-view-label" for="simple-view-toggle" id="simple-view-toggle-label">
                     {% trans 'vypis.templates.vypis.simple_view.label' %}
                 </label>
                 <input class="form-check-input" type="checkbox" id="simple-view-toggle" onchange="toggleSimpleView()"

--- a/webclient/vypis/templates/vypis/vypis_list.html
+++ b/webclient/vypis/templates/vypis/vypis_list.html
@@ -2,14 +2,10 @@
 {% load template_filters %}
 {% load template_tags %}
 {% load i18n %}
-{% load compress %}
 {% load static %}
 
 {% block head %}
 {{ block.super }}
-{% compress css %}
-    <link type="text/x-scss" href="{% static 'theme.scss' %}" rel="stylesheet" media="print">
-{% endcompress %}
 <script src="{% static 'js/html-to-rtf-browser.js' %}"></script>
 <script src="{% static 'js/vypis-report.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
<!-- aiscr-pr-review:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4158

| Field | Value |
| --- | --- |
| Title | bug/3983-oprava seznamu a compressu |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4158 |
| Author | @jnihnat |
| Base ← head | `test` ← `bug/3983-oprava-seznamu-a-compressu` |
| Head SHA | `dbad7ff562f8556f684331f65c4b68b837d1028a` |
| Size | 4 files, +6 / −6 |
| State | OPEN |
| Marked AIS CR review baseline | `REQUEST_CHANGES` on `0410f82` (print `theme.scss` media mismatch) |
| Prior PR summary | marked description present but stale (still describes removed print compress / old head) |

## Purpose and scope

Fixes double middle-dot bullets in HTML→RTF export for list items, restores the výpis `theme.scss` `media="print"` compress path after review feedback, and makes the list-výpis simple-view label hide on narrow screens match the single-výpis behaviour (issue #3983).

## Change map by area

| Area | Files | What changes |
| --- | --- | --- |
| RTF export mapping | `webclient/static/js/html-to-rtf-browser.js` | Clear `li` `openingRtf` so bullets come only from the `ul` list definition |
| Print CSS delivery | `vypis.html`, `vypis_list.html` | Keep `{% compress css %}` + `theme.scss` `media="print"` (restored after round-1 finding); minor `{% load %}` reorder only |
| Narrow-screen label hide | `_app-vypis.scss`, `vypis_list.html` | Add `simple-view-label` on list toggle; drop extra `form-check` wrapper class; use `display: none !important` under `max-width: 649.98px` |

## Change walkthrough

Round 1 removed the print compress block and cleared the RTF `li` bullet prefix. Review requested changes because `base.html` loads `theme.scss` as `media="screen"` only. The author restored the print compress in both templates, then fixed list-only label visibility: the list template lacked `simple-view-label` (single výpis already had it), so narrow-screen hide CSS never matched; Bootstrap `form-check` styles also needed `!important` to win. That mismatch explains the split “label hidden / still visible” reports between single and list pages.

```mermaid
flowchart TD
  rtf["html-to-rtf li mapping"] --> rtfFix["openingRtf cleared"]
  rtfFix --> singleBullet["ul list def supplies one middle-dot"]
  printPath["vypis templates"] --> restorePrint["Keep theme.scss media=print compress"]
  listUi["vypis_list toggle"] --> addClass["Add simple-view-label"]
  scss["_app-vypis.scss narrow media"] --> importantHide["display none !important"]
  addClass --> importantHide
```

## Attention hints (summary only)

- Spot-check RTF export for `ul` and `ol` (shared `li` mapping).
- Confirm narrow viewport (~<650px) hides the simple-view label on **list** výpis the same way as single výpis.
- Print/A4 path is restored; no further print-CSS deletion remains in the final diff.

## Validation / test surfaces visible in the PR

- Visible in PR: author notes (“opraveno”, label-hide fix for list only); pre-commit, CodeQL/analyze, and GitGuardian reported passing.
- Not evidenced in the PR: browser print preview, RTF export fixture/manual capture, or automated UI tests for these templates.
- Reviewer-side this round: conductor direct diff analysis against head `dbad7ff`; Bugbot requested as auxiliary (may arrive separately).

## Lineage

Newest marked AIS CR review: `REQUEST_CHANGES` on `0410f82` (`<!-- aiscr-pr-review:v1 -->`) with one Serious finding on print stylesheet media mismatch plus a non-blocking RTF observation. Author restored print compress (`4306c08`) and added the list label-hide fix (`dbad7ff`). Marked PR summary exists in the description but still reflects the pre-restore scope and old head SHA.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
