### PR TITLE
Oprava náhledu obrázku 3D a PAS.

### DIFF
--- a/webclient/dokument/templates/dokument/detail_model_3D.html
+++ b/webclient/dokument/templates/dokument/detail_model_3D.html
@@ -17,7 +17,7 @@
 
     {% include "state_component_document.html" with dokument=dokument %}
 
-    <div class="card app-card-form">
+    <div class="card app-card-form app-table-list-container">
       <div class="card-header">
         <div class="app-fx app-left">
           {% trans "dokument.templates.detail_model_3D.nahledy3dModelu.cardHeader" %}

--- a/webclient/pas/templates/pas/detail.html
+++ b/webclient/pas/templates/pas/detail.html
@@ -15,7 +15,7 @@
     {% include "toolbar_pas.html" with sn=sn  showcontrols=True %}
     {% include "pas/state_component_pas.html" with sn=sn %}
 
-    <div class="card app-card-form">
+    <div class="card app-card-form app-table-list-container">
       <div class="card-header">
         <div class="app-fx app-left">
           {% trans "pas.templates.detail.fotografie" %}


### PR DESCRIPTION
<!-- aiscr-pr-review:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4159

| Field | Value |
| --- | --- |
| Title | Oprava náhledu obrázku 3D a PAS. |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4159 |
| Author | jhavrlant |
| Base ← head | `test` ← `bugfix/4150-nahled-css-detail` |
| Head SHA | `f4982fcba8cdde2c0094b30f26213912a4d2fc87` |
| Size | +2 / −2 across 2 files |
| State | OPEN |
| Marked AIS CR review baseline | none |
| Prior PR summary | none |

## Purpose and scope

Fixes oddly small file-preview thumbnails on the 3D model detail and PAS detail pages by adding the shared `app-table-list-container` class already used on document detail (`dok/detail.html`). Closes the remaining CSS part of [#4150](https://github.com/ARUP-CAS/aiscr-webamcr/issues/4150).

## Change map by area

| Area | Files | What changed |
| --- | --- | --- |
| Templates (preview cards) | `webclient/dokument/templates/dokument/detail_model_3D.html`, `webclient/pas/templates/pas/detail.html` | Add `app-table-list-container` next to `card app-card-form` on the soubory/fotografie card |

## Change walkthrough

Both detail templates wrap the file/preview table card the same way document detail already does, so nested `.app-table-list-container .table td .image-nahled` rules (including `max-height: 100px`) apply and thumbnail sizing matches the working dokument surface.

```mermaid
flowchart LR
  issue["Issue 4150: small previews on PAS and 3D detail"]
  docOk["dokument/dok/detail.html already has app-table-list-container"]
  css["_app-global.scss: .image-nahled sizing under .app-table-list-container"]
  pr["PR 4159 adds the class on 3D and PAS cards"]
  result["Thumbnail sizing aligned with dokument"]
  issue --> docOk
  docOk --> css
  css --> pr
  pr --> result
```

## Attention hints (summary only)

- Confirm visually on amcr-test PAS and 3D detail pages that large previews match dokument sizing.
- Scope is CSS class alignment only; no Python/JS behaviour changes.

## Validation / test surfaces visible in the PR

- Visible in the PR: CodeQL / Analyze (actions, javascript, python), GitGuardian, and pre-commit all pass on the head SHA.
- Not executed during this review: browser verification on amcr-test detail URLs from #4150.

## Lineage

First AIS CR review round for this PR. No marked prior review, no summary marker, no open review threads. Current PR description is only `#4150`.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
