### PR TITLE
v1.4.0-rc2

### DIFF
--- a/docs/source/12_zavislosti/python_knihovny.rst
+++ b/docs/source/12_zavislosti/python_knihovny.rst
@@ -308,7 +308,7 @@ Tento soubor je důležitý pro porozumění právním aspektům použitých kni
      - MIT License
      - https://foss.heptapod.net/openpyxl/et_xmlfile
    * - filelock
-     - 3.31.1
+     - 3.31.2
      - MIT
      - https://github.com/tox-dev/py-filelock
    * - freezegun

--- a/webclient/dokument/templates/dokument/detail_model_3D.html
+++ b/webclient/dokument/templates/dokument/detail_model_3D.html
@@ -17,7 +17,7 @@
 
     {% include "state_component_document.html" with dokument=dokument %}
 
-    <div class="card app-card-form">
+    <div class="card app-card-form app-table-list-container">
       <div class="card-header">
         <div class="app-fx app-left">
           {% trans "dokument.templates.detail_model_3D.nahledy3dModelu.cardHeader" %}

--- a/webclient/pas/templates/pas/detail.html
+++ b/webclient/pas/templates/pas/detail.html
@@ -15,7 +15,7 @@
     {% include "toolbar_pas.html" with sn=sn  showcontrols=True %}
     {% include "pas/state_component_pas.html" with sn=sn %}
 
-    <div class="card app-card-form">
+    <div class="card app-card-form app-table-list-container">
       <div class="card-header">
         <div class="app-fx app-left">
           {% trans "pas.templates.detail.fotografie" %}

--- a/webclient/static/js/html-to-rtf-browser.js
+++ b/webclient/static/js/html-to-rtf-browser.js
@@ -9071,7 +9071,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 },
                 {
                     opening: 'li',
-                    openingRtf: '{\\pnlvlblt\\b\\\'b7}',
+                    openingRtf: '',
                     closing: '/li',
                     closingRtf: '\\par'
                 },

--- a/webclient/static/scss/_app-theme-dark.scss
+++ b/webclient/static/scss/_app-theme-dark.scss
@@ -171,7 +171,6 @@ body.app-dark-theme {
                     .page-item {
                         &.active {
                             .page-link {
-                                background-color: $color;
                                 color: $white;
                                 display: flex;
                                 border: 1px solid #dee2e6;

--- a/webclient/static/scss/_app-vypis.scss
+++ b/webclient/static/scss/_app-vypis.scss
@@ -19,7 +19,7 @@
 
     @media (max-width: 649.98px) {
       .simple-view-label {
-        display: none;
+        display: none !important;
       }
     }
 

--- a/webclient/vypis/templates/vypis/vypis.html
+++ b/webclient/vypis/templates/vypis/vypis.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load template_filters %}
 {% load template_tags %}
-{% load i18n %}
 {% load compress %}
+{% load i18n %}
 {% load static %}
 
 {% block head %}

--- a/webclient/vypis/templates/vypis/vypis_list.html
+++ b/webclient/vypis/templates/vypis/vypis_list.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load template_filters %}
 {% load template_tags %}
-{% load i18n %}
 {% load compress %}
+{% load i18n %}
 {% load static %}
 
 {% block head %}
@@ -29,8 +29,8 @@
     </div>
     <div class="col-3 d-print-none align-self-center no-export">
         <div class="float-end d-flex align-items-center gap-2">
-            <div class="form-check form-switch form-check-reverse mb-0">
-                <label class="form-check-label" for="simple-view-toggle" id="simple-view-toggle-label">
+            <div class="form-switch form-check-reverse mb-0">
+                <label class="form-check-label simple-view-label" for="simple-view-toggle" id="simple-view-toggle-label">
                     {% trans 'vypis.templates.vypis.simple_view.label' %}
                 </label>
                 <input class="form-check-input" type="checkbox" id="simple-view-toggle" onchange="toggleSimpleView()"


### PR DESCRIPTION
<!-- aiscr-pr-review:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4160

| Field | Value |
| --- | --- |
| Title | v1.4.0-rc2 |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4160 |
| Author | motyc |
| Base ← head | `main` ← `test` |
| Head SHA | `15f5a1f9586d0e58631553542a1ea4dc183e5dd5` |
| Size | +8 / −9 across 7 files (3 commits) |
| State | OPEN |
| Marked AIS CR review baseline | none |
| Prior PR summary | none |

## Purpose and scope

Release-candidate promotion of `test` into `main` for **v1.4.0-rc2**. The PR body is empty; the change set is three already-merged bugfix PRs landed on `test` (pagination dark-theme styling, vypis list/compress/label fixes, and 3D/PAS preview container class). Scope is UI/template/static only — no backend, migration, or API surface in this diff.

## Change map by area

| Area | Paths | What changed |
| --- | --- | --- |
| 3D / PAS preview layout | `dokument/detail_model_3D.html`, `pas/detail.html` | Add `app-table-list-container` beside `app-card-form` on preview cards (#4159) |
| Vypis templates / compress | `vypis/vypis.html`, `vypis/vypis_list.html` | Restore `{% load compress %}` after i18n; tweak simple-view switch markup and label class (#4158) |
| Vypis / list styling | `_app-vypis.scss`, `html-to-rtf-browser.js` | Force-hide simple-view label on narrow viewports; remove duplicate bullet RTF marker for `<li>` (#4158) |
| Dark-theme pagination | `_app-theme-dark.scss` | Drop active page-link `background-color` override (#4157) |

## Change walkthrough

Three independent UI fixes ride this RC branch from `test` to `main`. Preview cards for 3D models and PAS photos gain the shared table-list container class so thumbnail layout matches other list containers. Vypis pages reload `compress` (needed for print media after it was removed while still loaded from `base.html` elsewhere), adjust the simple-view toggle markup/label class, and hide that label more aggressively on small screens; HTML→RTF list items no longer emit a second mid-dot bullet. Dark theme pagination stops painting an active background that conflicted with the intended link styling.

```mermaid
flowchart LR
  testBranch["test branch"] --> p4157["#4157 pagination dark theme"]
  testBranch --> p4158["#4158 vypis list / compress / label"]
  testBranch --> p4159["#4159 3D and PAS preview class"]
  p4157 --> rc["PR #4160 v1.4.0-rc2"]
  p4158 --> rc
  p4159 --> rc
  rc --> mainBranch["main"]
```

## Attention hints (summary only)

- Release PR `test` → `main`: confirm this is the intended RC cut and that staging on `test` already covers these three fixes.
- Template class / SCSS / compress load-order changes: visual check of dark-theme pagination, vypis list + print, and 3D/PAS photo cards.
- `html-to-rtf-browser.js` is a large vendor-ish static file with a one-line RTF list marker change — confirm export of bulleted lists still looks correct.

## Validation / test surfaces visible in the PR

- **Visible in the PR:** three merged bugfix commit messages (#4157, #4158, #4159); no CI status or test plan in the empty PR description; no automated test files in the diff.
- **Executed during this summary-only pass:** none (context gather and diff inspection only; no checks run, no formal review).

## Lineage

First AIS CR summary for this PR. No marked `<!-- aiscr-pr-review:v1 -->` review baseline and no prior marked summary comment or description. Auxiliary vendor reviews: none gathered.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
