### PR TITLE
Nastaven limit nofile

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,6 +2,10 @@
 services:
   web:
     image: docker.io/library/test_prod
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     secrets:
       - db_conf
       - mail_conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@
 services:
   web:
     image: ${amcr_image}
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     secrets:
       - db_conf
       - mail_conf


### PR DESCRIPTION
<!-- aiscr-review-pr:summary -->

# PR summary — ARUP-CAS/aiscr-webamcr#4162

| Field | Value |
| --- | --- |
| Title | Nastaven limit nofile |
| URL | https://github.com/ARUP-CAS/aiscr-webamcr/pull/4162 |
| Author | jhavrlant |
| Base ← head | `test` ← `bugfix/seznam-skryta-tabulka-fallback` |
| Head SHA | `ed89c5587b25c08f5c3e0b5a451542436b6cfb58` |
| Size | +8 / −0 across 2 files |
| State | OPEN |
| Marked AIS CR review baseline | none (first AIS CR review round) |
| Prior PR summary | none |

## Purpose and scope

Cap the container `nofile` (max open files / sockets) soft and hard limits for the `web` service at `65536` in the production and test Compose files. Without an explicit limit, containerd’s default (`2^30`) makes uWSGI binary reload close file descriptors in a very large loop, so restarts can take minutes. Scope is deploy Compose only (`docker-compose.yml`, `docker-compose-test.yml`); local-dev Compose files are unchanged.

## Change map by area

| Area | Files | What changed |
| --- | --- | --- |
| Deploy Compose (prod) | `docker-compose.yml` | Under `services.web`, add `ulimits.nofile` soft/hard `65536` |
| Deploy Compose (test) | `docker-compose-test.yml` | Same `ulimits.nofile` block on `services.web` |

## Change walkthrough

Both files add the same Compose `ulimits` block immediately under the `web` service image line, matching the existing Elasticsearch `ulimits.memlock` pattern elsewhere in the prod file. Soft and hard are equal, so the process cannot raise the ceiling at runtime. That bounds the FD range uWSGI walks on binary reload (e.g. from admin/`uwsgi.reload()` paths) without changing application code or the `scripts/uwsgi_site.ini` process model.

```mermaid
flowchart LR
  A[containerd default nofile ~2^30] --> B[uWSGI binary reload]
  B --> C[Close FDs in large loop]
  C --> D[Slow restart minutes]
  E[Compose ulimits nofile 65536] --> F[Same reload path]
  F --> G[Bounded FD close loop]
  G --> H[Faster restart]
```

## Attention hints (summary only)

- Head branch name `bugfix/seznam-skryta-tabulka-fallback` does not match the nofile / reload subject; worth confirming the branch was reused intentionally.
- Only the `web` service is limited; Celery and other services keep host/containerd defaults — consistent with a uWSGI-reload-focused fix.
- Local-dev Compose files (`docker-compose-dev-*.yml`) are out of scope for this PR.

## Validation / test surfaces visible in the PR

Visible on the PR: author describes the containerd / uWSGI reload motivation in Czech; CI shows passing `pre-commit`, CodeQL/Analyze (actions, javascript, python), and GitGuardian. A bot comment reports pre-commit hooks clean.

Not executed in this review session: no Compose deploy, no measured reload timing before/after, no runtime `ulimit -n` check inside a running `web` container.

## Lineage

No marked `<!-- aiscr-review-pr:v1 -->` review and no marked summary comment or description marker. Reviews list is empty; only the pre-commit bot issue comment is present. This is round one for AIS CR lineage.

---

This PR summary was prepared with AI assistance through the AIS CR review workflow; the posting reviewer reviewed and approved it for posting.
